### PR TITLE
feat: TV Mode - Redirect-based OAuth for TV browsers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,6 +104,7 @@ function App() {
     signOut,
     accessToken,
     useTvMode,
+    isGisUnavailable,
     tvSignIn,
     toggleTvMode,
   } = useAuth()
@@ -275,6 +276,7 @@ function App() {
         isReady={isReady}
         isSigningIn={isSigningIn}
         useTvMode={useTvMode}
+        isGisUnavailable={isGisUnavailable}
         onTvSignIn={tvSignIn}
         onToggleTvMode={toggleTvMode}
       />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,7 +95,18 @@ const loadScrollDensity = () => {
 }
 
 function App() {
-  const { isAuthenticated, isReady, isSigningIn, authNotice, signIn, signOut, accessToken } = useAuth()
+  const {
+    isAuthenticated,
+    isReady,
+    isSigningIn,
+    authNotice,
+    signIn,
+    signOut,
+    accessToken,
+    useTvMode,
+    tvSignIn,
+    toggleTvMode,
+  } = useAuth()
   const fixedDate = getFixedDate()
   const now = fixedDate ?? new Date()
   const currentYear = now.getFullYear()
@@ -263,6 +274,9 @@ function App() {
         authNotice={authNotice}
         isReady={isReady}
         isSigningIn={isSigningIn}
+        useTvMode={useTvMode}
+        onTvSignIn={tvSignIn}
+        onToggleTvMode={toggleTvMode}
       />
     )
   }

--- a/src/components/LandingPage.test.tsx
+++ b/src/components/LandingPage.test.tsx
@@ -26,12 +26,12 @@ describe('LandingPage', () => {
     render(
       <LandingPage
         onSignIn={vi.fn()}
-        authNotice="Sign-in is temporarily unavailable."
+        authNotice="Session expired. Sign in again."
       />
     )
 
     expect(screen.getByRole('alert')).toHaveTextContent(
-      'Sign-in is temporarily unavailable.'
+      'Session expired. Sign in again.'
     )
   })
 
@@ -52,9 +52,9 @@ describe('LandingPage', () => {
     expect(button).not.toBeDisabled()
     expect(button).toHaveAttribute('aria-busy', 'true')
 
+    // Spinner is conditionally rendered when signing in
     const spinner = button.querySelector('span.flex')
     expect(spinner).not.toBeNull()
-    expect(spinner).toHaveClass('opacity-100')
   })
 
   it('renders hero and mid-page sign-in buttons', () => {
@@ -87,8 +87,9 @@ describe('LandingPage', () => {
     const buttons = screen.getAllByRole('button', { name: 'Sign in with Google' })
     buttons.forEach((button) => {
       expect(button).toHaveAttribute('aria-busy', 'false')
+      // Spinner is not rendered when not signing in
       const spinner = button.querySelector('span.flex')
-      expect(spinner).toHaveClass('opacity-0')
+      expect(spinner).toBeNull()
     })
   })
 

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -7,6 +7,7 @@ interface LandingPageProps {
   isSigningIn?: boolean
   // TV Mode props
   useTvMode?: boolean
+  isGisUnavailable?: boolean
   onTvSignIn?: () => void
   onToggleTvMode?: (enabled: boolean) => void
 }
@@ -558,6 +559,7 @@ export function LandingPage({
   isReady = true,
   isSigningIn = false,
   useTvMode = false,
+  isGisUnavailable = false,
   onTvSignIn,
   onToggleTvMode,
 }: LandingPageProps) {
@@ -566,7 +568,7 @@ export function LandingPage({
 
   // Determine if we should show TV mode UI
   // Show when: explicitly in TV mode, or when GIS is unavailable
-  const showTvMode = useTvMode || authNotice?.includes('unavailable')
+  const showTvMode = useTvMode || isGisUnavailable
 
   // Handler for sign-in that routes to the appropriate flow
   const handleSignIn = useCallback(() => {
@@ -631,8 +633,8 @@ export function LandingPage({
             </p>
 
             <div className="mt-10 flex flex-col items-center gap-5">
-              {/* Show auth notice, but not "unavailable" when TV mode is active */}
-              {authNotice && !(showTvMode && authNotice.includes('unavailable')) ? (
+              {/* Show auth notice, but not GIS unavailable message when TV mode is active */}
+              {authNotice && !(showTvMode && isGisUnavailable) ? (
                 <div
                   role="alert"
                   className="w-full max-w-xl rounded-2xl border border-amber-200 bg-amber-50/80 px-4 py-3 text-sm text-amber-900"

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -5,6 +5,10 @@ interface LandingPageProps {
   authNotice?: string | null
   isReady?: boolean
   isSigningIn?: boolean
+  // TV Mode props
+  useTvMode?: boolean
+  onTvSignIn?: () => void
+  onToggleTvMode?: (enabled: boolean) => void
 }
 
 const IMAGE_WIDTH = 1280
@@ -553,9 +557,25 @@ export function LandingPage({
   authNotice,
   isReady = true,
   isSigningIn = false,
+  useTvMode = false,
+  onTvSignIn,
+  onToggleTvMode,
 }: LandingPageProps) {
   const { openShot, lightbox } = useScreenshotLightbox()
   const prefersReducedMotion = usePrefersReducedMotion()
+
+  // Determine if we should show TV mode UI
+  // Show when: explicitly in TV mode, or when GIS is unavailable
+  const showTvMode = useTvMode || authNotice?.includes('unavailable')
+
+  // Handler for sign-in that routes to the appropriate flow
+  const handleSignIn = useCallback(() => {
+    if (showTvMode && onTvSignIn) {
+      onTvSignIn()
+    } else {
+      onSignIn()
+    }
+  }, [showTvMode, onTvSignIn, onSignIn])
 
   return (
     <div className="landing-bg relative min-h-screen w-screen overflow-hidden text-zinc-950">
@@ -611,7 +631,8 @@ export function LandingPage({
             </p>
 
             <div className="mt-10 flex flex-col items-center gap-5">
-              {authNotice ? (
+              {/* Show auth notice, but not "unavailable" when TV mode is active */}
+              {authNotice && !(showTvMode && authNotice.includes('unavailable')) ? (
                 <div
                   role="alert"
                   className="w-full max-w-xl rounded-2xl border border-amber-200 bg-amber-50/80 px-4 py-3 text-sm text-amber-900"
@@ -619,10 +640,30 @@ export function LandingPage({
                   {authNotice}
                 </div>
               ) : null}
+              {/* TV Mode notice when active */}
+              {showTvMode ? (
+                <div
+                  className="w-full max-w-xl rounded-2xl border border-sky-200 bg-sky-50/80 px-4 py-3 text-sm text-sky-900"
+                >
+                  <strong>TV Mode:</strong> Using redirect-based sign-in for better compatibility.
+                  {useTvMode && onToggleTvMode ? (
+                    <>
+                      {' '}
+                      <button
+                        type="button"
+                        onClick={() => onToggleTvMode(false)}
+                        className="underline decoration-sky-300 underline-offset-2 transition hover:text-sky-700"
+                      >
+                        Switch back to popup mode
+                      </button>
+                    </>
+                  ) : null}
+                </div>
+              ) : null}
               <button
                 type="button"
-                onClick={onSignIn}
-                disabled={!isReady}
+                onClick={handleSignIn}
+                disabled={!showTvMode && !isReady}
                 aria-busy={isSigningIn}
                 className="relative inline-flex items-center justify-center gap-3 rounded-full border border-zinc-300 bg-white px-8 py-4 text-base font-medium text-zinc-700 shadow-sm transition hover:bg-zinc-50 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-70"
               >
@@ -644,7 +685,7 @@ export function LandingPage({
                     d="M24 48c6.48 0 11.93-2.13 15.9-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.17 2.3-6.26 0-11.59-3.86-13.47-9.19l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
                   />
                 </svg>
-                <span>Sign in with Google</span>
+                <span>Sign in with Google{showTvMode ? ' (TV Mode)' : ''}</span>
                 {isSigningIn ? (
                   <span className="absolute right-4 flex h-5 w-5 items-center justify-center">
                     <span className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600" />
@@ -661,6 +702,18 @@ export function LandingPage({
                   Open Source
                 </a>
                 {' - Your data never leaves your browser.'}
+                {!showTvMode && onToggleTvMode ? (
+                  <>
+                    {' · '}
+                    <button
+                      type="button"
+                      onClick={() => onToggleTvMode(true)}
+                      className="underline decoration-zinc-300 underline-offset-2 transition hover:text-zinc-600"
+                    >
+                      Try TV Mode
+                    </button>
+                  </>
+                ) : null}
               </p>
               <p className="text-xs text-zinc-400">
                 <a href="/privacy.html" className="underline decoration-zinc-300 underline-offset-2 transition hover:text-zinc-600">Privacy Policy</a>
@@ -760,8 +813,8 @@ export function LandingPage({
             </p>
             <button
               type="button"
-              onClick={onSignIn}
-              disabled={!isReady}
+              onClick={handleSignIn}
+              disabled={!showTvMode && !isReady}
               aria-busy={isSigningIn}
               className="relative inline-flex items-center justify-center gap-3 rounded-full border border-zinc-300 bg-white px-8 py-4 text-base font-medium text-zinc-700 shadow-sm transition hover:bg-zinc-50 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-70"
             >
@@ -783,7 +836,7 @@ export function LandingPage({
                   d="M24 48c6.48 0 11.93-2.13 15.9-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.17 2.3-6.26 0-11.59-3.86-13.47-9.19l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
                 />
               </svg>
-              <span>Sign in with Google</span>
+              <span>Sign in with Google{showTvMode ? ' (TV Mode)' : ''}</span>
               {isSigningIn ? (
                 <span className="absolute right-4 flex h-5 w-5 items-center justify-center">
                   <span className="h-5 w-5 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600" />

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -130,6 +130,9 @@ export function useAuth() {
   // TV Mode: Use redirect-based OAuth when GIS library fails to load
   const [useTvMode, setUseTvMode] = useState(() => getTvModePreference())
 
+  // Track if GIS is unavailable (typed flag instead of string matching)
+  const [isGisUnavailable, setIsGisUnavailable] = useState(false)
+
   useEffect(() => {
     if (fixtureMode) {
       return
@@ -191,6 +194,7 @@ export function useAuth() {
           if (intervalId) {
             window.clearInterval(intervalId)
           }
+          setIsGisUnavailable(true)
           setAuthNotice('Google sign-in unavailable. Refresh to try again.')
           // Auto-enable TV mode on TV browsers when GIS fails
           if (isTVBrowser()) {
@@ -259,6 +263,7 @@ export function useAuth() {
     const status = signIn()
     if (status === 'unavailable') {
       setIsSigningIn(false)
+      setIsGisUnavailable(true)
       setAuthNotice('Google sign-in unavailable. Refresh to try again.')
       return
     }
@@ -305,12 +310,12 @@ export function useAuth() {
       setTvModePreference(enabled)
 
       // If enabling TV mode and GIS was unavailable, clear the notice
-      if (enabled && authNotice?.includes('unavailable')) {
+      if (enabled && isGisUnavailable) {
         setAuthNotice(null)
         setIsReady(true)
       }
     },
-    [authNotice, fixtureMode],
+    [isGisUnavailable, fixtureMode],
   )
 
   return {
@@ -322,6 +327,7 @@ export function useAuth() {
     signOut: handleSignOut,
     // TV Mode
     useTvMode,
+    isGisUnavailable,
     tvSignIn: handleTvSignIn,
     toggleTvMode: handleToggleTvMode,
   }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -9,9 +9,22 @@ import {
   signIn,
   signOut,
   storeAuth,
+  CLIENT_ID,
+  SCOPES,
 } from '../services/auth'
 import type { AuthState } from '../types/auth'
 import { isFixtureMode } from '../utils/env'
+import {
+  buildOAuthRedirectUrl,
+  clearHashFromUrl,
+  extractErrorFromHash,
+  extractTokenFromHash,
+} from '../utils/manualOAuth'
+import {
+  getTvModePreference,
+  isTVBrowser,
+  setTvModePreference,
+} from '../utils/tvDetection'
 
 const EMPTY_STATE: AuthState = {
   isAuthenticated: false,
@@ -30,30 +43,92 @@ const FIXTURE_STATE: AuthState = {
   expiresAt: null,
 }
 
-const getInitialAuthState = (fixtureMode: boolean): AuthState => {
+interface InitialAuthResult {
+  authState: AuthState
+  isReady: boolean
+  authNotice: string | null
+  handledOAuthCallback: boolean
+}
+
+const getInitialAuthState = (fixtureMode: boolean): InitialAuthResult => {
   if (fixtureMode) {
-    return FIXTURE_STATE
+    return {
+      authState: FIXTURE_STATE,
+      isReady: true,
+      authNotice: null,
+      handledOAuthCallback: false,
+    }
   }
 
+  // Check for OAuth error in URL hash (redirect flow callback)
+  const oauthError = extractErrorFromHash()
+  if (oauthError) {
+    clearHashFromUrl()
+    return {
+      authState: EMPTY_STATE,
+      isReady: true,
+      authNotice:
+        oauthError.error === 'access_denied'
+          ? 'Sign-in cancelled. Try again when ready.'
+          : `Sign-in failed: ${oauthError.errorDescription ?? oauthError.error}`,
+      handledOAuthCallback: true,
+    }
+  }
+
+  // Check for OAuth token in URL hash (redirect flow callback)
+  const tokenData = extractTokenFromHash()
+  if (tokenData) {
+    const expiresAt = storeAuth(tokenData.accessToken, tokenData.expiresIn)
+    clearHashFromUrl()
+    return {
+      authState: {
+        isAuthenticated: true,
+        user: null,
+        accessToken: tokenData.accessToken,
+        expiresAt,
+      },
+      isReady: true,
+      authNotice: null,
+      handledOAuthCallback: true,
+    }
+  }
+
+  // Check for stored auth
   const stored = getStoredAuth()
-  if (!stored) {
-    return EMPTY_STATE
+  if (stored) {
+    return {
+      authState: {
+        isAuthenticated: true,
+        user: null,
+        accessToken: stored.accessToken,
+        expiresAt: stored.expiresAt,
+      },
+      isReady: false,
+      authNotice: null,
+      handledOAuthCallback: false,
+    }
   }
 
   return {
-    isAuthenticated: true,
-    user: null,
-    accessToken: stored.accessToken,
-    expiresAt: stored.expiresAt,
+    authState: EMPTY_STATE,
+    isReady: false,
+    authNotice: null,
+    handledOAuthCallback: false,
   }
 }
 
 export function useAuth() {
   const fixtureMode = isFixtureMode()
-  const [authState, setAuthState] = useState<AuthState>(() => getInitialAuthState(fixtureMode))
-  const [isReady, setIsReady] = useState(fixtureMode)
+
+  // Initialize all auth state from a single source to handle OAuth callbacks
+  const [initialResult] = useState(() => getInitialAuthState(fixtureMode))
+  const [authState, setAuthState] = useState<AuthState>(initialResult.authState)
+  const [isReady, setIsReady] = useState(initialResult.isReady || fixtureMode)
   const [isSigningIn, setIsSigningIn] = useState(false)
-  const [authNotice, setAuthNotice] = useState<string | null>(null)
+  const [authNotice, setAuthNotice] = useState<string | null>(initialResult.authNotice)
+
+  // TV Mode: Use redirect-based OAuth when GIS library fails to load
+  const [useTvMode, setUseTvMode] = useState(() => getTvModePreference())
 
   useEffect(() => {
     if (fixtureMode) {
@@ -117,6 +192,11 @@ export function useAuth() {
             window.clearInterval(intervalId)
           }
           setAuthNotice('Google sign-in unavailable. Refresh to try again.')
+          // Auto-enable TV mode on TV browsers when GIS fails
+          if (isTVBrowser()) {
+            setUseTvMode(true)
+            setTvModePreference(true)
+          }
         }
       }, INIT_POLL_INTERVAL_MS)
     }, 0)
@@ -197,6 +277,42 @@ export function useAuth() {
     setAuthNotice(null)
   }, [fixtureMode])
 
+  // TV Mode sign-in: redirect to Google OAuth (no popup)
+  const handleTvSignIn = useCallback(() => {
+    if (fixtureMode) {
+      return
+    }
+
+    if (!CLIENT_ID) {
+      setAuthNotice('Missing Google client ID. Check .env.local.')
+      return
+    }
+
+    setAuthNotice(null)
+    const redirectUri = window.location.origin + window.location.pathname
+    const url = buildOAuthRedirectUrl(CLIENT_ID, redirectUri, SCOPES)
+    window.location.href = url
+  }, [fixtureMode])
+
+  // Toggle TV mode on/off with persistence
+  const handleToggleTvMode = useCallback(
+    (enabled: boolean) => {
+      if (fixtureMode) {
+        return
+      }
+
+      setUseTvMode(enabled)
+      setTvModePreference(enabled)
+
+      // If enabling TV mode and GIS was unavailable, clear the notice
+      if (enabled && authNotice?.includes('unavailable')) {
+        setAuthNotice(null)
+        setIsReady(true)
+      }
+    },
+    [authNotice, fixtureMode],
+  )
+
   return {
     ...authState,
     isReady,
@@ -204,5 +320,9 @@ export function useAuth() {
     authNotice,
     signIn: handleSignIn,
     signOut: handleSignOut,
+    // TV Mode
+    useTvMode,
+    tvSignIn: handleTvSignIn,
+    toggleTvMode: handleToggleTvMode,
   }
 }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,7 +1,10 @@
 import { clearEventCaches } from './cache'
 
-const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID
-const SCOPES = 'https://www.googleapis.com/auth/calendar.readonly'
+/** Google OAuth client ID from environment */
+export const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined
+
+/** OAuth scope for read-only calendar access */
+export const SCOPES = 'https://www.googleapis.com/auth/calendar.readonly'
 
 const ACCESS_TOKEN_KEY = 'yearbird:accessToken'
 const EXPIRES_AT_KEY = 'yearbird:expiresAt'

--- a/src/utils/manualOAuth.test.ts
+++ b/src/utils/manualOAuth.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import {
+  buildOAuthRedirectUrl,
+  clearHashFromUrl,
+  extractErrorFromHash,
+  extractTokenFromHash,
+  hasOAuthResponse,
+} from './manualOAuth'
+
+describe('manualOAuth', () => {
+  describe('buildOAuthRedirectUrl', () => {
+    it('builds correct OAuth URL with all parameters', () => {
+      const url = buildOAuthRedirectUrl(
+        'test-client-id',
+        'https://example.com/callback',
+        'https://www.googleapis.com/auth/calendar.readonly',
+      )
+
+      const parsed = new URL(url)
+      expect(parsed.origin).toBe('https://accounts.google.com')
+      expect(parsed.pathname).toBe('/o/oauth2/v2/auth')
+      expect(parsed.searchParams.get('client_id')).toBe('test-client-id')
+      expect(parsed.searchParams.get('redirect_uri')).toBe('https://example.com/callback')
+      expect(parsed.searchParams.get('response_type')).toBe('token')
+      expect(parsed.searchParams.get('scope')).toBe('https://www.googleapis.com/auth/calendar.readonly')
+      expect(parsed.searchParams.get('include_granted_scopes')).toBe('true')
+      expect(parsed.searchParams.get('prompt')).toBe('select_account')
+    })
+
+    it('encodes special characters in parameters', () => {
+      const url = buildOAuthRedirectUrl(
+        'client&id=test',
+        'https://example.com/call back',
+        'scope with spaces',
+      )
+
+      const parsed = new URL(url)
+      expect(parsed.searchParams.get('client_id')).toBe('client&id=test')
+      expect(parsed.searchParams.get('redirect_uri')).toBe('https://example.com/call back')
+      expect(parsed.searchParams.get('scope')).toBe('scope with spaces')
+    })
+  })
+
+  describe('extractTokenFromHash', () => {
+    const originalWindow = globalThis.window
+
+    beforeEach(() => {
+      // Create a mock window with location
+      globalThis.window = {
+        location: {
+          hash: '',
+          pathname: '/',
+          search: '',
+        },
+        history: {
+          replaceState: vi.fn(),
+        },
+      } as unknown as Window & typeof globalThis
+    })
+
+    afterEach(() => {
+      globalThis.window = originalWindow
+    })
+
+    it('returns null when hash is empty', () => {
+      window.location.hash = ''
+      expect(extractTokenFromHash()).toBeNull()
+    })
+
+    it('returns null when hash has no access_token', () => {
+      window.location.hash = '#expires_in=3600&token_type=Bearer'
+      expect(extractTokenFromHash()).toBeNull()
+    })
+
+    it('returns null when hash has no expires_in', () => {
+      window.location.hash = '#access_token=test-token&token_type=Bearer'
+      expect(extractTokenFromHash()).toBeNull()
+    })
+
+    it('extracts token data from valid hash', () => {
+      window.location.hash = '#access_token=test-token-123&expires_in=3600&token_type=Bearer'
+      const result = extractTokenFromHash()
+      expect(result).toEqual({
+        accessToken: 'test-token-123',
+        expiresIn: 3600,
+      })
+    })
+
+    it('handles URL-encoded tokens', () => {
+      window.location.hash = '#access_token=ya29.test%2Btoken&expires_in=3599'
+      const result = extractTokenFromHash()
+      expect(result?.accessToken).toBe('ya29.test+token')
+    })
+
+    it('returns null for non-numeric expires_in', () => {
+      window.location.hash = '#access_token=test-token&expires_in=invalid'
+      expect(extractTokenFromHash()).toBeNull()
+    })
+
+    it('returns null for zero or negative expires_in', () => {
+      window.location.hash = '#access_token=test-token&expires_in=0'
+      expect(extractTokenFromHash()).toBeNull()
+
+      window.location.hash = '#access_token=test-token&expires_in=-100'
+      expect(extractTokenFromHash()).toBeNull()
+    })
+
+    it('returns null when window is undefined', () => {
+      globalThis.window = undefined as unknown as Window & typeof globalThis
+      expect(extractTokenFromHash()).toBeNull()
+    })
+  })
+
+  describe('extractErrorFromHash', () => {
+    const originalWindow = globalThis.window
+
+    beforeEach(() => {
+      globalThis.window = {
+        location: {
+          hash: '',
+          pathname: '/',
+          search: '',
+        },
+        history: {
+          replaceState: vi.fn(),
+        },
+      } as unknown as Window & typeof globalThis
+    })
+
+    afterEach(() => {
+      globalThis.window = originalWindow
+    })
+
+    it('returns null when hash is empty', () => {
+      window.location.hash = ''
+      expect(extractErrorFromHash()).toBeNull()
+    })
+
+    it('returns null when no error in hash', () => {
+      window.location.hash = '#access_token=test&expires_in=3600'
+      expect(extractErrorFromHash()).toBeNull()
+    })
+
+    it('extracts error without description', () => {
+      window.location.hash = '#error=access_denied'
+      const result = extractErrorFromHash()
+      expect(result).toEqual({
+        error: 'access_denied',
+        errorDescription: undefined,
+      })
+    })
+
+    it('extracts error with description', () => {
+      window.location.hash = '#error=access_denied&error_description=User%20denied%20access'
+      const result = extractErrorFromHash()
+      expect(result).toEqual({
+        error: 'access_denied',
+        errorDescription: 'User denied access',
+      })
+    })
+
+    it('returns null when window is undefined', () => {
+      globalThis.window = undefined as unknown as Window & typeof globalThis
+      expect(extractErrorFromHash()).toBeNull()
+    })
+  })
+
+  describe('clearHashFromUrl', () => {
+    const originalWindow = globalThis.window
+
+    beforeEach(() => {
+      globalThis.window = {
+        location: {
+          hash: '#access_token=test',
+          pathname: '/app',
+          search: '?foo=bar',
+        },
+        history: {
+          replaceState: vi.fn(),
+        },
+      } as unknown as Window & typeof globalThis
+    })
+
+    afterEach(() => {
+      globalThis.window = originalWindow
+    })
+
+    it('calls replaceState with path and search (no hash)', () => {
+      clearHashFromUrl()
+      expect(window.history.replaceState).toHaveBeenCalledWith({}, '', '/app?foo=bar')
+    })
+
+    it('handles empty search', () => {
+      window.location.search = ''
+      clearHashFromUrl()
+      expect(window.history.replaceState).toHaveBeenCalledWith({}, '', '/app')
+    })
+
+    it('does not throw when window is undefined', () => {
+      globalThis.window = undefined as unknown as Window & typeof globalThis
+      expect(() => clearHashFromUrl()).not.toThrow()
+    })
+  })
+
+  describe('hasOAuthResponse', () => {
+    const originalWindow = globalThis.window
+
+    beforeEach(() => {
+      globalThis.window = {
+        location: {
+          hash: '',
+          pathname: '/',
+          search: '',
+        },
+      } as unknown as Window & typeof globalThis
+    })
+
+    afterEach(() => {
+      globalThis.window = originalWindow
+    })
+
+    it('returns false when hash is empty', () => {
+      window.location.hash = ''
+      expect(hasOAuthResponse()).toBe(false)
+    })
+
+    it('returns true when hash has access_token', () => {
+      window.location.hash = '#access_token=test'
+      expect(hasOAuthResponse()).toBe(true)
+    })
+
+    it('returns true when hash has error', () => {
+      window.location.hash = '#error=access_denied'
+      expect(hasOAuthResponse()).toBe(true)
+    })
+
+    it('returns false for non-OAuth hash', () => {
+      window.location.hash = '#section-1'
+      expect(hasOAuthResponse()).toBe(false)
+    })
+
+    it('returns false when window is undefined', () => {
+      globalThis.window = undefined as unknown as Window & typeof globalThis
+      expect(hasOAuthResponse()).toBe(false)
+    })
+  })
+})

--- a/src/utils/manualOAuth.ts
+++ b/src/utils/manualOAuth.ts
@@ -1,0 +1,150 @@
+/**
+ * Manual OAuth Utility for TV Mode
+ *
+ * Implements Google OAuth 2.0 implicit flow for environments where
+ * Google Identity Services (GIS) library cannot load (e.g., TV browsers).
+ *
+ * This uses redirect-based OAuth instead of popup-based GIS flow.
+ *
+ * @see https://developers.google.com/identity/protocols/oauth2/javascript-implicit-flow
+ */
+
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
+
+export interface TokenData {
+  accessToken: string
+  expiresIn: number
+}
+
+export interface OAuthError {
+  error: string
+  errorDescription?: string
+}
+
+/**
+ * Builds the Google OAuth authorization URL for implicit flow.
+ *
+ * @param clientId - Google OAuth client ID
+ * @param redirectUri - URI to redirect back to after authorization
+ * @param scope - OAuth scope(s) to request
+ * @returns The full authorization URL to redirect the user to
+ */
+export function buildOAuthRedirectUrl(
+  clientId: string,
+  redirectUri: string,
+  scope: string,
+): string {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'token', // Implicit flow - returns token in URL hash
+    scope,
+    include_granted_scopes: 'true',
+    // Prompt user to select account (useful if they have multiple Google accounts)
+    prompt: 'select_account',
+  })
+  return `${GOOGLE_AUTH_URL}?${params.toString()}`
+}
+
+/**
+ * Extracts the OAuth token from the URL hash fragment.
+ *
+ * After a successful OAuth redirect, Google returns the access token
+ * in the URL hash like: #access_token=xxx&expires_in=3600&token_type=Bearer
+ *
+ * @returns Token data if present, null otherwise
+ */
+export function extractTokenFromHash(): TokenData | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  const hash = window.location.hash.slice(1) // Remove leading #
+  if (!hash) {
+    return null
+  }
+
+  const params = new URLSearchParams(hash)
+  const accessToken = params.get('access_token')
+  const expiresInRaw = params.get('expires_in')
+
+  if (!accessToken || !expiresInRaw) {
+    return null
+  }
+
+  const expiresIn = Number.parseInt(expiresInRaw, 10)
+  if (!Number.isFinite(expiresIn) || expiresIn <= 0) {
+    return null
+  }
+
+  return { accessToken, expiresIn }
+}
+
+/**
+ * Extracts OAuth error information from the URL hash fragment.
+ *
+ * If the user denies access or an error occurs, Google returns
+ * error information in the hash like: #error=access_denied&error_description=...
+ *
+ * @returns Error data if present, null otherwise
+ */
+export function extractErrorFromHash(): OAuthError | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  const hash = window.location.hash.slice(1)
+  if (!hash) {
+    return null
+  }
+
+  const params = new URLSearchParams(hash)
+  const error = params.get('error')
+
+  if (!error) {
+    return null
+  }
+
+  return {
+    error,
+    errorDescription: params.get('error_description') ?? undefined,
+  }
+}
+
+/**
+ * Clears the URL hash fragment without triggering a page reload.
+ *
+ * This should be called after extracting the token to clean up
+ * the URL and prevent the token from being visible in the browser history.
+ */
+export function clearHashFromUrl(): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  // Use replaceState to avoid adding to browser history
+  window.history.replaceState(
+    {},
+    '',
+    window.location.pathname + window.location.search,
+  )
+}
+
+/**
+ * Checks if the current URL hash contains OAuth response data.
+ *
+ * @returns true if hash contains access_token or error parameters
+ */
+export function hasOAuthResponse(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  const hash = window.location.hash.slice(1)
+  if (!hash) {
+    return false
+  }
+
+  const params = new URLSearchParams(hash)
+  return params.has('access_token') || params.has('error')
+}

--- a/src/utils/tvDetection.test.ts
+++ b/src/utils/tvDetection.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import {
+  clearTvModePreference,
+  getTvModePreference,
+  isTVBrowser,
+  setTvModePreference,
+} from './tvDetection'
+
+describe('tvDetection', () => {
+  describe('isTVBrowser', () => {
+    const originalNavigator = globalThis.navigator
+
+    afterEach(() => {
+      // Restore original navigator
+      Object.defineProperty(globalThis, 'navigator', {
+        value: originalNavigator,
+        writable: true,
+      })
+    })
+
+    const testCases = [
+      // Android TV / Google TV
+      { ua: 'Mozilla/5.0 (Linux; Android 10; BRAVIA 4K GB) AppleWebKit/537.36', expected: true, name: 'Sony Bravia TV' },
+      { ua: 'Mozilla/5.0 (Linux; Android 9; SHIELD Android TV)', expected: true, name: 'Nvidia Shield TV' },
+      { ua: 'Mozilla/5.0 (Linux; Android 7.1.2; AFT*) AppleWebKit/537.36', expected: true, name: 'Fire TV (AFT*)' },
+      { ua: 'Mozilla/5.0 (Linux; Android 9; AFTA)', expected: true, name: 'Fire TV Stick (AFTA)' },
+      { ua: 'Mozilla/5.0 (Linux; Android 9; AFTB)', expected: true, name: 'Fire TV Stick (AFTB)' },
+
+      // Smart TV platforms
+      { ua: 'Mozilla/5.0 (SMART-TV; Linux; Tizen 5.5)', expected: true, name: 'Samsung Tizen TV' },
+      { ua: 'Mozilla/5.0 (Web0S; Linux/SmartTV)', expected: true, name: 'LG webOS TV (Web0S)' },
+      { ua: 'Mozilla/5.0 (webOS.TV-2021)', expected: true, name: 'LG webOS TV (webOS)' },
+      { ua: 'Mozilla/5.0 (SmartTV/1.0)', expected: true, name: 'Generic SmartTV' },
+
+      // TV browsers
+      { ua: 'TVBro/1.0 (Android TV)', expected: true, name: 'TVBro browser' },
+      { ua: 'Puffin TV/1.0', expected: true, name: 'Puffin TV browser' },
+
+      // Gaming consoles
+      { ua: 'Mozilla/5.0 (PlayStation 5)', expected: true, name: 'PlayStation 5' },
+      { ua: 'Mozilla/5.0 (PlayStation 4)', expected: true, name: 'PlayStation 4' },
+      { ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox)', expected: true, name: 'Xbox browser' },
+      { ua: 'Nintendo/1.0', expected: true, name: 'Nintendo' },
+
+      // Streaming devices
+      { ua: 'Roku/DVP-10.5 (10.5.0.4025)', expected: true, name: 'Roku' },
+      { ua: 'Mozilla/5.0 (CrKey armv7l 1.5.1) AppleWebKit/537.36', expected: true, name: 'Chromecast' },
+
+      // TV manufacturers
+      { ua: 'Mozilla/5.0 (Vizio SmartCast)', expected: true, name: 'Vizio SmartCast' },
+      { ua: 'Mozilla/5.0 (Hisense VIDAA)', expected: true, name: 'Hisense TV' },
+      { ua: 'Mozilla/5.0 (Philips TV)', expected: true, name: 'Philips TV' },
+
+      // Desktop browsers (should NOT match)
+      { ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36', expected: false, name: 'Chrome Windows' },
+      { ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36', expected: false, name: 'Chrome Mac' },
+      { ua: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36', expected: false, name: 'Chrome Linux' },
+
+      // Mobile browsers (should NOT match)
+      { ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15', expected: false, name: 'Safari iOS' },
+      { ua: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36', expected: false, name: 'Chrome Android' },
+    ]
+
+    for (const { ua, expected, name } of testCases) {
+      it(`returns ${expected} for ${name}`, () => {
+        Object.defineProperty(globalThis, 'navigator', {
+          value: { userAgent: ua },
+          writable: true,
+        })
+        expect(isTVBrowser()).toBe(expected)
+      })
+    }
+
+    it('returns false when navigator is undefined', () => {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: undefined,
+        writable: true,
+      })
+      expect(isTVBrowser()).toBe(false)
+    })
+  })
+
+  describe('TV mode preference', () => {
+    const mockStorage: Record<string, string> = {}
+
+    beforeEach(() => {
+      // Clear mock storage
+      for (const key of Object.keys(mockStorage)) {
+        delete mockStorage[key]
+      }
+
+      // Mock localStorage
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn((key: string) => mockStorage[key] ?? null),
+        setItem: vi.fn((key: string, value: string) => {
+          mockStorage[key] = value
+        }),
+        removeItem: vi.fn((key: string) => {
+          delete mockStorage[key]
+        }),
+      })
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    describe('getTvModePreference', () => {
+      it('returns false when not set', () => {
+        expect(getTvModePreference()).toBe(false)
+      })
+
+      it('returns true when set to "true"', () => {
+        mockStorage['yearbird:tvMode'] = 'true'
+        expect(getTvModePreference()).toBe(true)
+      })
+
+      it('returns false when set to any other value', () => {
+        mockStorage['yearbird:tvMode'] = 'false'
+        expect(getTvModePreference()).toBe(false)
+      })
+
+      it('returns false when localStorage throws', () => {
+        vi.stubGlobal('localStorage', {
+          getItem: vi.fn(() => {
+            throw new Error('Storage access denied')
+          }),
+        })
+        expect(getTvModePreference()).toBe(false)
+      })
+    })
+
+    describe('setTvModePreference', () => {
+      it('sets "true" in localStorage when enabled', () => {
+        setTvModePreference(true)
+        expect(mockStorage['yearbird:tvMode']).toBe('true')
+      })
+
+      it('removes from localStorage when disabled', () => {
+        mockStorage['yearbird:tvMode'] = 'true'
+        setTvModePreference(false)
+        expect(mockStorage['yearbird:tvMode']).toBeUndefined()
+      })
+
+      it('does not throw when localStorage throws', () => {
+        vi.stubGlobal('localStorage', {
+          setItem: vi.fn(() => {
+            throw new Error('Storage access denied')
+          }),
+          removeItem: vi.fn(() => {
+            throw new Error('Storage access denied')
+          }),
+        })
+        expect(() => setTvModePreference(true)).not.toThrow()
+        expect(() => setTvModePreference(false)).not.toThrow()
+      })
+    })
+
+    describe('clearTvModePreference', () => {
+      it('removes the preference from localStorage', () => {
+        mockStorage['yearbird:tvMode'] = 'true'
+        clearTvModePreference()
+        expect(mockStorage['yearbird:tvMode']).toBeUndefined()
+      })
+    })
+  })
+})

--- a/src/utils/tvDetection.ts
+++ b/src/utils/tvDetection.ts
@@ -1,0 +1,115 @@
+/**
+ * TV Browser Detection Utility
+ *
+ * Detects TV browsers where Google Identity Services (GIS) library
+ * typically fails to load, requiring the fallback redirect-based OAuth flow.
+ *
+ * Supported TV platforms:
+ * - Google TV / Android TV (TVBro, Puffin TV, sideloaded Chrome)
+ * - Amazon Fire TV
+ * - Samsung Tizen
+ * - LG webOS
+ * - Roku
+ * - PlayStation/Xbox browsers
+ */
+
+const TV_MODE_STORAGE_KEY = 'yearbird:tvMode'
+
+/**
+ * Known TV browser user agent patterns.
+ * These patterns match common TV browsers and smart TV platforms.
+ */
+const TV_USER_AGENT_PATTERNS = [
+  // Android TV / Google TV
+  /Android.*TV/i,
+  /Android.*AFT/i, // Amazon Fire TV
+  /\bAFT[A-Z]\b/, // Fire TV device codes (AFTA, AFTB, etc.)
+
+  // Smart TV platforms
+  /Tizen/i, // Samsung Smart TV
+  /Web0S/i, // LG Smart TV (note: Web0S with zero)
+  /webOS/i, // LG Smart TV alternate
+  /SMART-TV/i,
+  /SmartTV/i,
+
+  // TV browsers
+  /TV Safari/i,
+  /TVBro/i,
+  /Puffin TV/i,
+
+  // Gaming consoles (browser mode)
+  /PlayStation/i,
+  /Xbox/i,
+  /Nintendo/i,
+
+  // Roku
+  /Roku/i,
+
+  // Generic TV indicators
+  /\bTV\b/i, // Generic "TV" in UA
+  /CrKey/i, // Chromecast
+  /BRAVIA/i, // Sony Bravia
+  /Vizio/i,
+  /Hisense/i,
+  /Philips/i,
+]
+
+/**
+ * Detects if the current browser is running on a TV device.
+ *
+ * @returns true if the user agent matches known TV browser patterns
+ */
+export function isTVBrowser(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false
+  }
+
+  const ua = navigator.userAgent
+  return TV_USER_AGENT_PATTERNS.some((pattern) => pattern.test(ua))
+}
+
+/**
+ * Gets the persisted TV mode preference from localStorage.
+ *
+ * @returns true if user has manually enabled TV mode, false otherwise
+ */
+export function getTvModePreference(): boolean {
+  if (typeof localStorage === 'undefined') {
+    return false
+  }
+
+  try {
+    return localStorage.getItem(TV_MODE_STORAGE_KEY) === 'true'
+  } catch {
+    // localStorage may be unavailable in private mode
+    return false
+  }
+}
+
+/**
+ * Sets the TV mode preference in localStorage.
+ *
+ * @param enabled - Whether to enable or disable TV mode
+ */
+export function setTvModePreference(enabled: boolean): void {
+  if (typeof localStorage === 'undefined') {
+    return
+  }
+
+  try {
+    if (enabled) {
+      localStorage.setItem(TV_MODE_STORAGE_KEY, 'true')
+    } else {
+      localStorage.removeItem(TV_MODE_STORAGE_KEY)
+    }
+  } catch {
+    // Ignore storage access issues
+  }
+}
+
+/**
+ * Clears the TV mode preference from localStorage.
+ */
+export function clearTvModePreference(): void {
+  setTvModePreference(false)
+}


### PR DESCRIPTION
## Summary

- Implements redirect-based OAuth flow as a fallback when Google Identity Services (GIS) library fails to load on TV browsers
- Detects TV browsers via user-agent patterns (Google TV, Fire TV, Android TV, webOS, Tizen, game consoles)
- Automatically enables TV mode when GIS times out on TV browsers
- Users can manually toggle TV mode via "Try TV Mode" link

## Changes

| File | Description |
|------|-------------|
| `src/utils/tvDetection.ts` | TV browser detection utility with UA patterns and preference storage |
| `src/utils/manualOAuth.ts` | OAuth redirect URL builder and token/error extraction from URL hash |
| `src/hooks/useAuth.ts` | TV mode state, hash token extraction during init, manual sign-in handler |
| `src/components/LandingPage.tsx` | TV mode UI with notices, sign-in toggle, and redirect flow |
| `src/services/auth.ts` | Export CLIENT_ID and SCOPES for manual OAuth |

## Test plan

- [x] TypeScript check passes
- [x] ESLint passes
- [x] All 302 tests pass (57 new tests for TV detection and OAuth utilities)
- [x] Production build succeeds
- [ ] Manual test: Sign in using TV mode on desktop browser
- [ ] Manual test: Sign in on actual TV browser (if available)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)