### PR TITLE
feat: Store configuration in Google Drive appDataFolder

### DIFF
--- a/docs/GOOGLE_OAUTH.md
+++ b/docs/GOOGLE_OAUTH.md
@@ -106,3 +106,17 @@ This is normal for unverified apps. Click:
 - Your calendar data never leaves your browser
 - OAuth tokens are stored in localStorage (cleared on sign out)
 - We don't store any data on servers
+
+## Cloud Sync (Optional)
+
+If you enable cloud sync in settings, Yearbird will request an additional scope:
+
+- `drive.appdata` — Allows storing your settings in a private app folder in Google Drive
+
+This is a **non-sensitive scope** that:
+- Only allows access to Yearbird's own private folder
+- Cannot read or modify any other files in your Drive
+- Data is hidden from your Drive UI
+- Enables syncing your filters and categories across devices
+
+You can enable cloud sync from the Filters panel. This will prompt for consent to the Drive scope.

--- a/src/components/CloudSyncToggle.tsx
+++ b/src/components/CloudSyncToggle.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react'
+import type { SyncStatus } from '../types/cloudConfig'
+import { useCloudSync } from '../hooks/useCloudSync'
+import { Button } from './ui/button'
+
+interface CloudSyncToggleProps {
+  className?: string
+}
+
+function formatLastSync(timestamp: number | null): string {
+  if (!timestamp) {
+    return 'Never'
+  }
+  const date = new Date(timestamp)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+
+  if (diffMins < 1) {
+    return 'Just now'
+  }
+  if (diffMins < 60) {
+    return `${diffMins}m ago`
+  }
+  const diffHours = Math.floor(diffMins / 60)
+  if (diffHours < 24) {
+    return `${diffHours}h ago`
+  }
+  return date.toLocaleDateString()
+}
+
+function StatusIndicator({ status }: { status: SyncStatus }) {
+  switch (status) {
+    case 'synced':
+      return (
+        <span className="flex items-center gap-1 text-emerald-600">
+          <svg className="h-3 w-3" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
+            <path d="M10 3L4.5 8.5 2 6" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          <span className="text-xs">Synced</span>
+        </span>
+      )
+    case 'syncing':
+      return (
+        <span className="flex items-center gap-1 text-sky-600">
+          <svg className="h-3 w-3 animate-spin" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+            <circle cx="6" cy="6" r="5" stroke="currentColor" strokeWidth="1.5" strokeDasharray="20" strokeDashoffset="5" />
+          </svg>
+          <span className="text-xs">Syncing...</span>
+        </span>
+      )
+    case 'offline':
+      return (
+        <span className="flex items-center gap-1 text-amber-600">
+          <svg className="h-3 w-3" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
+            <path d="M6 1v6M6 9v1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+          <span className="text-xs">Offline</span>
+        </span>
+      )
+    case 'error':
+      return (
+        <span className="flex items-center gap-1 text-red-600">
+          <svg className="h-3 w-3" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
+            <circle cx="6" cy="6" r="5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+            <path d="M6 4v3M6 8.5v.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+          <span className="text-xs">Error</span>
+        </span>
+      )
+    case 'needs-consent':
+      return (
+        <span className="flex items-center gap-1 text-amber-600">
+          <svg className="h-3 w-3" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
+            <path d="M6 1L11 11H1L6 1z" stroke="currentColor" strokeWidth="1" fill="none" />
+            <path d="M6 5v2M6 8.5v.5" stroke="currentColor" strokeWidth="1" strokeLinecap="round" />
+          </svg>
+          <span className="text-xs">Needs setup</span>
+        </span>
+      )
+    default:
+      return null
+  }
+}
+
+/**
+ * Cloud sync toggle component for the settings panel.
+ * Allows users to enable/disable sync with Google Drive appDataFolder.
+ */
+export function CloudSyncToggle({ className }: CloudSyncToggleProps) {
+  const {
+    isEnabled,
+    status,
+    error,
+    lastSyncedAt,
+    enable,
+    disable,
+    syncNow,
+    clearError,
+  } = useCloudSync()
+
+  const [isEnabling, setIsEnabling] = useState(false)
+
+  const handleToggle = async () => {
+    if (isEnabled) {
+      disable()
+    } else {
+      setIsEnabling(true)
+      try {
+        await enable()
+      } finally {
+        setIsEnabling(false)
+      }
+    }
+  }
+
+  const handleRetry = async () => {
+    clearError()
+    await syncNow()
+  }
+
+  return (
+    <div className={`rounded-lg border border-zinc-200 bg-zinc-50 p-3 ${className || ''}`}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <svg className="h-4 w-4 text-zinc-600" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path d="M5.5 16a3.5 3.5 0 01-.369-6.98 4 4 0 117.753-1.977A4.5 4.5 0 1113.5 16h-8z" />
+            </svg>
+            <h4 className="text-sm font-medium text-zinc-900">Cloud Sync</h4>
+          </div>
+          <p className="mt-1 text-xs text-zinc-500">
+            Sync your settings across devices via Google Drive.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          role="switch"
+          aria-checked={isEnabled}
+          disabled={isEnabling}
+          onClick={handleToggle}
+          className={`
+            relative inline-flex h-6 w-10 flex-shrink-0 cursor-pointer rounded-full
+            border-2 border-transparent transition-colors duration-200 ease-in-out
+            focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2
+            disabled:opacity-50 disabled:cursor-wait
+            ${isEnabled ? 'bg-sky-500' : 'bg-zinc-300'}
+          `}
+        >
+          <span className="sr-only">
+            {isEnabled ? 'Disable cloud sync' : 'Enable cloud sync'}
+          </span>
+          <span
+            aria-hidden="true"
+            className={`
+              pointer-events-none inline-block h-5 w-5 transform rounded-full
+              bg-white shadow ring-0 transition duration-200 ease-in-out
+              ${isEnabled ? 'translate-x-4' : 'translate-x-0'}
+            `}
+          />
+        </button>
+      </div>
+
+      {isEnabled && (
+        <div className="mt-2 flex items-center justify-between border-t border-zinc-200 pt-2">
+          <div className="flex items-center gap-2">
+            <StatusIndicator status={status} />
+            {status === 'synced' && lastSyncedAt && (
+              <span className="text-xs text-zinc-400">
+                Last: {formatLastSync(lastSyncedAt)}
+              </span>
+            )}
+          </div>
+
+          {status === 'error' && error && (
+            <Button plain onClick={handleRetry} className="text-xs">
+              Retry
+            </Button>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-2 rounded bg-red-50 p-2">
+          <p className="text-xs text-red-600">{error}</p>
+        </div>
+      )}
+
+      {!isEnabled && (
+        <p className="mt-2 text-xs text-zinc-400">
+          Your settings are stored locally. Enable sync to access them on other devices.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -9,6 +9,7 @@ import type {
 } from '../types/calendar'
 import type { EventFilter } from '../services/filters'
 import { secondaryActionClasses } from '../styles/secondaryActions'
+import { CloudSyncToggle } from './CloudSyncToggle'
 import { CustomCategoryManager } from './CustomCategoryManager'
 import { Button } from './ui/button'
 
@@ -405,6 +406,10 @@ export function FilterPanel({
                 onRemoveCustomCategory={onRemoveCustomCategory}
               />
             </div>
+          </div>
+
+          <div className="mt-3 border-t border-zinc-100 pt-3">
+            <CloudSyncToggle />
           </div>
         </Dialog.Panel>
       </div>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -648,6 +648,10 @@ export function LandingPage({
                   className="w-full max-w-xl rounded-2xl border border-sky-200 bg-sky-50/80 px-4 py-3 text-sm text-sky-900"
                 >
                   <strong>TV Mode:</strong> Using redirect-based sign-in for better compatibility.
+                  {' '}
+                  <span className="text-sky-700">
+                    If sign-in is blocked, set your browser's user agent to "Desktop Chrome" in settings.
+                  </span>
                   {useTvMode && onToggleTvMode ? (
                     <>
                       {' '}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -650,7 +650,7 @@ export function LandingPage({
                   <strong>TV Mode:</strong> Using redirect-based sign-in for better compatibility.
                   {' '}
                   <span className="text-sky-700">
-                    If sign-in is blocked, set your browser's user agent to "Desktop Chrome" in settings.
+                    If sign-in is blocked, set your browser&apos;s user agent to &quot;Desktop Chrome&quot; in settings.
                   </span>
                   {useTvMode && onToggleTvMode ? (
                     <>

--- a/src/hooks/useBuiltInCategories.ts
+++ b/src/hooks/useBuiltInCategories.ts
@@ -4,6 +4,7 @@ import {
   enableBuiltInCategory,
   getDisabledBuiltInCategories,
 } from '../services/builtInCategories'
+import { scheduleSyncToCloud } from '../services/syncManager'
 import type { BuiltInCategory } from '../types/calendar'
 
 interface UseBuiltInCategoriesResult {
@@ -20,11 +21,13 @@ export function useBuiltInCategories(): UseBuiltInCategoriesResult {
   const handleDisable = useCallback((category: BuiltInCategory) => {
     const next = disableBuiltInCategory(category)
     setDisabledBuiltInCategories(next)
+    scheduleSyncToCloud()
   }, [])
 
   const handleEnable = useCallback((category: BuiltInCategory) => {
     const next = enableBuiltInCategory(category)
     setDisabledBuiltInCategories(next)
+    scheduleSyncToCloud()
   }, [])
 
   return {

--- a/src/hooks/useCalendarVisibility.ts
+++ b/src/hooks/useCalendarVisibility.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { GoogleCalendarListEntry } from '../types/calendar'
 import { getDisabledCalendars, setDisabledCalendars } from '../services/calendarVisibility'
+import { scheduleSyncToCloud } from '../services/syncManager'
 
 interface UseCalendarVisibilityResult {
   disabledCalendarIds: string[]
@@ -43,6 +44,7 @@ export function useCalendarVisibility(
         }
         const next = [...cleaned, id]
         setDisabledCalendars(next)
+        scheduleSyncToCloud()
         return next
       })
     },
@@ -58,6 +60,7 @@ export function useCalendarVisibility(
         }
         const next = cleaned.filter((entry) => entry !== id)
         setDisabledCalendars(next)
+        scheduleSyncToCloud()
         return next
       })
     },

--- a/src/hooks/useCloudSync.ts
+++ b/src/hooks/useCloudSync.ts
@@ -1,0 +1,134 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { SyncStatus } from '../types/cloudConfig'
+import { hasDriveScope, requestDriveScope } from '../services/auth'
+import {
+  getSyncSettings,
+  getSyncStatus,
+  getLastSyncError,
+  clearSyncError,
+  enableSync,
+  disableSync,
+  performSync,
+  isSyncEnabled,
+} from '../services/syncManager'
+
+interface UseCloudSyncResult {
+  /** Whether cloud sync is enabled */
+  isEnabled: boolean
+  /** Current sync status */
+  status: SyncStatus
+  /** Last sync error message, if any */
+  error: string | null
+  /** Timestamp of last successful sync */
+  lastSyncedAt: number | null
+  /** Whether Drive scope has been granted */
+  hasDriveAccess: boolean
+  /** Enable cloud sync (will request Drive scope if needed) */
+  enable: () => Promise<boolean>
+  /** Disable cloud sync */
+  disable: () => void
+  /** Force a sync now */
+  syncNow: () => Promise<boolean>
+  /** Clear the last error */
+  clearError: () => void
+}
+
+/**
+ * Hook for managing cloud sync state in React components.
+ */
+export function useCloudSync(): UseCloudSyncResult {
+  const [isEnabled, setIsEnabled] = useState(() => isSyncEnabled())
+  const [status, setStatus] = useState<SyncStatus>(() => getSyncStatus())
+  const [error, setError] = useState<string | null>(() => getLastSyncError())
+  const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(
+    () => getSyncSettings().lastSyncedAt
+  )
+  const [hasDriveAccess, setHasDriveAccess] = useState(() => hasDriveScope())
+
+  // Update state when settings change
+  const refreshState = useCallback(() => {
+    setIsEnabled(isSyncEnabled())
+    setStatus(getSyncStatus())
+    setError(getLastSyncError())
+    setLastSyncedAt(getSyncSettings().lastSyncedAt)
+    setHasDriveAccess(hasDriveScope())
+  }, [])
+
+  // Listen for online/offline events
+  useEffect(() => {
+    const handleOnline = () => refreshState()
+    const handleOffline = () => refreshState()
+
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+
+    return () => {
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+    }
+  }, [refreshState])
+
+  // Listen for storage events (cross-tab sync)
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === 'yearbird:cloud-sync-settings') {
+        refreshState()
+      }
+    }
+
+    window.addEventListener('storage', handleStorage)
+    return () => window.removeEventListener('storage', handleStorage)
+  }, [refreshState])
+
+  const enable = useCallback(async (): Promise<boolean> => {
+    // First check if we already have Drive scope
+    if (!hasDriveScope()) {
+      // Request Drive scope from user
+      setStatus('syncing')
+      const granted = await requestDriveScope()
+      if (!granted) {
+        setStatus('needs-consent')
+        return false
+      }
+      setHasDriveAccess(true)
+    }
+
+    // Enable sync and perform initial sync
+    setStatus('syncing')
+    const success = await enableSync()
+    refreshState()
+    return success
+  }, [refreshState])
+
+  const disable = useCallback(() => {
+    disableSync()
+    refreshState()
+  }, [refreshState])
+
+  const syncNow = useCallback(async (): Promise<boolean> => {
+    if (!isEnabled) {
+      return false
+    }
+    setStatus('syncing')
+    const success = await performSync()
+    refreshState()
+    return success
+  }, [isEnabled, refreshState])
+
+  const clearError = useCallback(() => {
+    clearSyncError()
+    setError(null)
+  }, [])
+
+  return {
+    isEnabled,
+    status,
+    error,
+    lastSyncedAt,
+    hasDriveAccess,
+    enable,
+    disable,
+    syncNow,
+    clearError,
+  }
+}

--- a/src/hooks/useCustomCategories.ts
+++ b/src/hooks/useCustomCategories.ts
@@ -7,6 +7,7 @@ import {
   type CustomCategoryInput,
   type CustomCategoryResult,
 } from '../services/customCategories'
+import { scheduleSyncToCloud } from '../services/syncManager'
 import type { CustomCategoryId } from '../types/calendar'
 import type { CustomCategory } from '../types/categories'
 
@@ -26,6 +27,7 @@ export function useCustomCategories(): UseCustomCategoriesResult {
     const result = addCustomCategory(input)
     if (result.category) {
       setCustomCategories((prev) => [...prev, result.category!])
+      scheduleSyncToCloud()
     }
     return result
   }, [])
@@ -36,6 +38,7 @@ export function useCustomCategories(): UseCustomCategoriesResult {
       setCustomCategories((prev) =>
         prev.map((entry) => (entry.id === id ? result.category! : entry))
       )
+      scheduleSyncToCloud()
     }
     return result
   }, [])
@@ -43,6 +46,7 @@ export function useCustomCategories(): UseCustomCategoriesResult {
   const handleRemove = useCallback((id: CustomCategoryId) => {
     removeCustomCategory(id)
     setCustomCategories((prev) => prev.filter((entry) => entry.id !== id))
+    scheduleSyncToCloud()
   }, [])
 
   return {

--- a/src/hooks/useFilters.ts
+++ b/src/hooks/useFilters.ts
@@ -6,6 +6,7 @@ import {
   removeFilter,
   type EventFilter,
 } from '../services/filters'
+import { scheduleSyncToCloud } from '../services/syncManager'
 import type { YearbirdEvent } from '../types/calendar'
 
 interface UseFiltersResult {
@@ -25,11 +26,13 @@ export function useFilters(): UseFiltersResult {
     }
     addFilter(trimmed)
     setFilters(getFilters())
+    scheduleSyncToCloud()
   }, [])
 
   const remove = useCallback((id: string) => {
     removeFilter(id)
     setFilters((prev) => prev.filter((filter) => filter.id !== id))
+    scheduleSyncToCloud()
   }, [])
 
   const filterEvents = useCallback(

--- a/src/services/driveSync.test.ts
+++ b/src/services/driveSync.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+
+// Mock auth module before importing driveSync
+vi.mock('./auth', () => ({
+  getStoredAuth: vi.fn(() => ({
+    accessToken: 'test-token',
+    expiresAt: Date.now() + 3600000,
+  })),
+}))
+
+// Mock fetch globally
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+// Now import driveSync functions
+import {
+  findConfigFile,
+  readCloudConfig,
+  writeCloudConfig,
+  deleteCloudConfig,
+  checkDriveAccess,
+} from './driveSync'
+import type { CloudConfig } from '../types/cloudConfig'
+
+describe('driveSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetch.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('findConfigFile', () => {
+    it('returns file when found', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          files: [{ id: 'file-123', name: 'yearbird-config.json', mimeType: 'application/json' }],
+        }),
+      })
+
+      const result = await findConfigFile()
+
+      expect(result.success).toBe(true)
+      expect(result.data?.id).toBe('file-123')
+    })
+
+    it('returns null when no file exists', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ files: [] }),
+      })
+
+      const result = await findConfigFile()
+
+      expect(result.success).toBe(true)
+      expect(result.data).toBeNull()
+    })
+
+    it('returns error on API failure', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        json: () => Promise.resolve({ error: { message: 'Access denied' } }),
+      })
+
+      const result = await findConfigFile()
+
+      expect(result.success).toBe(false)
+      expect(result.error?.code).toBe(403)
+    })
+  })
+
+  describe('readCloudConfig', () => {
+    it('returns null when no config file exists', async () => {
+      // Mock findConfigFile returning no files
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ files: [] }),
+      })
+
+      const result = await readCloudConfig()
+
+      expect(result.success).toBe(true)
+      expect(result.data).toBeNull()
+    })
+
+    it('returns validated config when file exists', async () => {
+      const validConfig: CloudConfig = {
+        version: 1,
+        updatedAt: Date.now(),
+        deviceId: 'test-device',
+        filters: [],
+        disabledCalendars: [],
+        disabledBuiltInCategories: [],
+        customCategories: [],
+      }
+
+      // Mock findConfigFile
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          files: [{ id: 'file-123', name: 'yearbird-config.json', mimeType: 'application/json' }],
+        }),
+      })
+
+      // Mock file download
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(validConfig),
+      })
+
+      const result = await readCloudConfig()
+
+      expect(result.success).toBe(true)
+      expect(result.data?.version).toBe(1)
+      expect(result.data?.deviceId).toBe('test-device')
+    })
+
+    it('returns error for invalid config structure', async () => {
+      // Mock findConfigFile
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          files: [{ id: 'file-123', name: 'yearbird-config.json', mimeType: 'application/json' }],
+        }),
+      })
+
+      // Mock file download with invalid data
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ invalid: 'data', version: 999 }),
+      })
+
+      const result = await readCloudConfig()
+
+      expect(result.success).toBe(false)
+      expect(result.error?.code).toBe(400)
+      expect(result.error?.message).toContain('Invalid')
+    })
+  })
+
+  describe('writeCloudConfig', () => {
+    const validConfig: CloudConfig = {
+      version: 1,
+      updatedAt: Date.now(),
+      deviceId: 'test-device',
+      filters: [],
+      disabledCalendars: [],
+      disabledBuiltInCategories: [],
+      customCategories: [],
+    }
+
+    it('creates new file when none exists', async () => {
+      // Mock findConfigFile - no existing file
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ files: [] }),
+      })
+
+      // Mock file creation
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'new-file-id', name: 'yearbird-config.json' }),
+      })
+
+      const result = await writeCloudConfig(validConfig)
+
+      expect(result.success).toBe(true)
+      expect(result.data?.id).toBe('new-file-id')
+
+      // Verify POST was called for creation
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      const createCall = mockFetch.mock.calls[1]
+      expect(createCall[0]).toContain('uploadType=multipart')
+      expect(createCall[1].method).toBe('POST')
+    })
+
+    it('updates existing file', async () => {
+      // Mock findConfigFile - existing file
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          files: [{ id: 'existing-file-id', name: 'yearbird-config.json' }],
+        }),
+      })
+
+      // Mock file update
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'existing-file-id', name: 'yearbird-config.json' }),
+      })
+
+      const result = await writeCloudConfig(validConfig)
+
+      expect(result.success).toBe(true)
+
+      // Verify PATCH was called for update
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      const updateCall = mockFetch.mock.calls[1]
+      expect(updateCall[0]).toContain('existing-file-id')
+      expect(updateCall[1].method).toBe('PATCH')
+    })
+  })
+
+  describe('deleteCloudConfig', () => {
+    it('deletes existing file', async () => {
+      // Mock findConfigFile
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          files: [{ id: 'file-to-delete', name: 'yearbird-config.json' }],
+        }),
+      })
+
+      // Mock delete
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+      })
+
+      const result = await deleteCloudConfig()
+
+      expect(result.success).toBe(true)
+
+      // Verify DELETE was called
+      const deleteCall = mockFetch.mock.calls[1]
+      expect(deleteCall[0]).toContain('file-to-delete')
+      expect(deleteCall[1].method).toBe('DELETE')
+    })
+
+    it('succeeds when no file exists', async () => {
+      // Mock findConfigFile - no file
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ files: [] }),
+      })
+
+      const result = await deleteCloudConfig()
+
+      expect(result.success).toBe(true)
+      expect(mockFetch).toHaveBeenCalledTimes(1) // Only findConfigFile called
+    })
+  })
+
+  describe('checkDriveAccess', () => {
+    it('returns true when API is accessible', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ files: [] }),
+      })
+
+      const result = await checkDriveAccess()
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false on API error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        json: () => Promise.resolve({ error: { message: 'Token expired' } }),
+      })
+
+      const result = await checkDriveAccess()
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false when offline', async () => {
+      const originalOnLine = navigator.onLine
+      Object.defineProperty(navigator, 'onLine', { value: false, configurable: true })
+
+      const result = await checkDriveAccess()
+
+      expect(result).toBe(false)
+
+      Object.defineProperty(navigator, 'onLine', { value: originalOnLine, configurable: true })
+    })
+  })
+
+  describe('retry logic', () => {
+    it('retries on 5xx errors', async () => {
+      // First call fails with 500
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.resolve({ error: { message: 'Server error' } }),
+      })
+
+      // Second call succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ files: [] }),
+      })
+
+      const result = await findConfigFile()
+
+      expect(result.success).toBe(true)
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    }, 10000) // Increase timeout for retry delays
+
+    it('does not retry on 4xx errors (except 429)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        json: () => Promise.resolve({ error: { message: 'Access denied' } }),
+      })
+
+      const result = await findConfigFile()
+
+      expect(result.success).toBe(false)
+      expect(result.error?.code).toBe(403)
+      expect(mockFetch).toHaveBeenCalledTimes(1) // No retry
+    })
+  })
+})

--- a/src/services/driveSync.ts
+++ b/src/services/driveSync.ts
@@ -1,0 +1,357 @@
+/**
+ * Google Drive appDataFolder service for cloud config sync.
+ *
+ * The appDataFolder is a special hidden folder in Google Drive:
+ * - Private to this app only
+ * - Hidden from user's Drive UI
+ * - Per-user isolated storage
+ * - Uses normal Drive quota (but configs are tiny)
+ *
+ * @see https://developers.google.com/workspace/drive/api/guides/appdata
+ */
+
+import type { CloudConfig } from '../types/cloudConfig'
+import { getStoredAuth } from './auth'
+
+const DRIVE_API_BASE = 'https://www.googleapis.com/drive/v3'
+const DRIVE_UPLOAD_BASE = 'https://www.googleapis.com/upload/drive/v3'
+const CONFIG_FILENAME = 'yearbird-config.json'
+const MIME_TYPE = 'application/json'
+
+export interface DriveError {
+  code: number
+  message: string
+  status?: string
+}
+
+export interface DriveSyncResult<T> {
+  success: boolean
+  data?: T
+  error?: DriveError
+}
+
+/**
+ * Get authorization headers for Drive API requests
+ */
+function getAuthHeaders(): HeadersInit | null {
+  const auth = getStoredAuth()
+  if (!auth) {
+    return null
+  }
+  return {
+    Authorization: `Bearer ${auth.accessToken}`,
+  }
+}
+
+/**
+ * Make an authenticated request to the Drive API
+ */
+async function driveRequest<T>(
+  url: string,
+  options: RequestInit = {}
+): Promise<DriveSyncResult<T>> {
+  const authHeaders = getAuthHeaders()
+  if (!authHeaders) {
+    return {
+      success: false,
+      error: { code: 401, message: 'Not authenticated' },
+    }
+  }
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        ...authHeaders,
+        ...options.headers,
+      },
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      return {
+        success: false,
+        error: {
+          code: response.status,
+          message: errorData.error?.message || response.statusText,
+          status: errorData.error?.status,
+        },
+      }
+    }
+
+    // Handle 204 No Content
+    if (response.status === 204) {
+      return { success: true }
+    }
+
+    const data = await response.json()
+    return { success: true, data }
+  } catch (error) {
+    return {
+      success: false,
+      error: {
+        code: 0,
+        message: error instanceof Error ? error.message : 'Network error',
+      },
+    }
+  }
+}
+
+interface DriveFile {
+  id: string
+  name: string
+  mimeType: string
+  modifiedTime?: string
+}
+
+interface DriveFileList {
+  files: DriveFile[]
+  nextPageToken?: string
+}
+
+/**
+ * Find the config file in appDataFolder
+ */
+export async function findConfigFile(): Promise<DriveSyncResult<DriveFile | null>> {
+  const params = new URLSearchParams({
+    spaces: 'appDataFolder',
+    fields: 'files(id,name,mimeType,modifiedTime)',
+    q: `name='${CONFIG_FILENAME}'`,
+  })
+
+  const result = await driveRequest<DriveFileList>(
+    `${DRIVE_API_BASE}/files?${params.toString()}`
+  )
+
+  if (!result.success) {
+    return { success: false, error: result.error }
+  }
+
+  const file = result.data?.files?.[0] || null
+  return { success: true, data: file }
+}
+
+/**
+ * Read the cloud config from appDataFolder
+ */
+export async function readCloudConfig(): Promise<DriveSyncResult<CloudConfig | null>> {
+  // First, find the config file
+  const findResult = await findConfigFile()
+  if (!findResult.success) {
+    return { success: false, error: findResult.error }
+  }
+
+  if (!findResult.data) {
+    // No config file exists yet
+    return { success: true, data: null }
+  }
+
+  // Download the file content
+  const params = new URLSearchParams({
+    alt: 'media',
+  })
+
+  const result = await driveRequest<CloudConfig>(
+    `${DRIVE_API_BASE}/files/${findResult.data.id}?${params.toString()}`
+  )
+
+  if (!result.success) {
+    return { success: false, error: result.error }
+  }
+
+  return { success: true, data: result.data ?? null }
+}
+
+/**
+ * Write the cloud config to appDataFolder.
+ * Creates the file if it doesn't exist, updates it otherwise.
+ */
+export async function writeCloudConfig(
+  config: CloudConfig
+): Promise<DriveSyncResult<DriveFile>> {
+  const authHeaders = getAuthHeaders()
+  if (!authHeaders) {
+    return {
+      success: false,
+      error: { code: 401, message: 'Not authenticated' },
+    }
+  }
+
+  // First, check if the file exists
+  const findResult = await findConfigFile()
+  if (!findResult.success) {
+    return { success: false, error: findResult.error }
+  }
+
+  const fileId = findResult.data?.id
+  const configJson = JSON.stringify(config, null, 2)
+
+  if (fileId) {
+    // Update existing file
+    return updateConfigFile(fileId, configJson, authHeaders)
+  } else {
+    // Create new file
+    return createConfigFile(configJson, authHeaders)
+  }
+}
+
+/**
+ * Create a new config file in appDataFolder
+ */
+async function createConfigFile(
+  content: string,
+  authHeaders: HeadersInit
+): Promise<DriveSyncResult<DriveFile>> {
+  // Use multipart upload for simplicity
+  const metadata = {
+    name: CONFIG_FILENAME,
+    mimeType: MIME_TYPE,
+    parents: ['appDataFolder'],
+  }
+
+  const boundary = '-------yearbird_boundary'
+  const body = [
+    `--${boundary}`,
+    'Content-Type: application/json; charset=UTF-8',
+    '',
+    JSON.stringify(metadata),
+    `--${boundary}`,
+    `Content-Type: ${MIME_TYPE}`,
+    '',
+    content,
+    `--${boundary}--`,
+  ].join('\r\n')
+
+  try {
+    const response = await fetch(
+      `${DRIVE_UPLOAD_BASE}/files?uploadType=multipart&fields=id,name,mimeType,modifiedTime`,
+      {
+        method: 'POST',
+        headers: {
+          ...authHeaders,
+          'Content-Type': `multipart/related; boundary=${boundary}`,
+        },
+        body,
+      }
+    )
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      return {
+        success: false,
+        error: {
+          code: response.status,
+          message: errorData.error?.message || response.statusText,
+          status: errorData.error?.status,
+        },
+      }
+    }
+
+    const data = await response.json()
+    return { success: true, data }
+  } catch (error) {
+    return {
+      success: false,
+      error: {
+        code: 0,
+        message: error instanceof Error ? error.message : 'Network error',
+      },
+    }
+  }
+}
+
+/**
+ * Update an existing config file
+ */
+async function updateConfigFile(
+  fileId: string,
+  content: string,
+  authHeaders: HeadersInit
+): Promise<DriveSyncResult<DriveFile>> {
+  try {
+    const response = await fetch(
+      `${DRIVE_UPLOAD_BASE}/files/${fileId}?uploadType=media&fields=id,name,mimeType,modifiedTime`,
+      {
+        method: 'PATCH',
+        headers: {
+          ...authHeaders,
+          'Content-Type': MIME_TYPE,
+        },
+        body: content,
+      }
+    )
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      return {
+        success: false,
+        error: {
+          code: response.status,
+          message: errorData.error?.message || response.statusText,
+          status: errorData.error?.status,
+        },
+      }
+    }
+
+    const data = await response.json()
+    return { success: true, data }
+  } catch (error) {
+    return {
+      success: false,
+      error: {
+        code: 0,
+        message: error instanceof Error ? error.message : 'Network error',
+      },
+    }
+  }
+}
+
+/**
+ * Delete the config file from appDataFolder.
+ * Used when user disables cloud sync.
+ */
+export async function deleteCloudConfig(): Promise<DriveSyncResult<void>> {
+  const findResult = await findConfigFile()
+  if (!findResult.success) {
+    return { success: false, error: findResult.error }
+  }
+
+  if (!findResult.data) {
+    // No file to delete
+    return { success: true }
+  }
+
+  const result = await driveRequest<void>(
+    `${DRIVE_API_BASE}/files/${findResult.data.id}`,
+    { method: 'DELETE' }
+  )
+
+  return result
+}
+
+/**
+ * Check if Drive API is accessible (online and authenticated)
+ */
+export async function checkDriveAccess(): Promise<boolean> {
+  const auth = getStoredAuth()
+  if (!auth) {
+    return false
+  }
+
+  if (!navigator.onLine) {
+    return false
+  }
+
+  // Quick check by listing appDataFolder (minimal quota usage)
+  const params = new URLSearchParams({
+    spaces: 'appDataFolder',
+    pageSize: '1',
+    fields: 'files(id)',
+  })
+
+  const result = await driveRequest<DriveFileList>(
+    `${DRIVE_API_BASE}/files?${params.toString()}`
+  )
+
+  return result.success
+}

--- a/src/services/syncManager.test.ts
+++ b/src/services/syncManager.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+  getSyncSettings,
+  saveSyncSettings,
+  isSyncEnabled,
+  getSyncStatus,
+  buildCloudConfigFromLocal,
+  mergeConfigs,
+  applyCloudConfigToLocal,
+  clearSyncError,
+  disableSync,
+} from './syncManager'
+import type { CloudConfig, CloudSyncSettings } from '../types/cloudConfig'
+
+// Mock auth module
+vi.mock('./auth', () => ({
+  hasDriveScope: vi.fn(() => true),
+}))
+
+// Mock driveSync module
+vi.mock('./driveSync', () => ({
+  readCloudConfig: vi.fn(),
+  writeCloudConfig: vi.fn(),
+  checkDriveAccess: vi.fn(),
+}))
+
+// Mock data service modules
+vi.mock('./filters', () => ({
+  getFilters: vi.fn(() => []),
+}))
+
+vi.mock('./calendarVisibility', () => ({
+  getDisabledCalendars: vi.fn(() => []),
+}))
+
+vi.mock('./builtInCategories', () => ({
+  getDisabledBuiltInCategories: vi.fn(() => []),
+}))
+
+vi.mock('./customCategories', () => ({
+  getCustomCategories: vi.fn(() => []),
+}))
+
+describe('syncManager', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('getSyncSettings', () => {
+    it('returns default settings when nothing stored', () => {
+      const settings = getSyncSettings()
+      expect(settings.enabled).toBe(false)
+      expect(settings.lastSyncedAt).toBeNull()
+      expect(settings.deviceId).toBeDefined()
+      expect(settings.deviceId.length).toBeGreaterThan(0)
+    })
+
+    it('returns stored settings when present', () => {
+      const stored: CloudSyncSettings = {
+        enabled: true,
+        lastSyncedAt: 1234567890,
+        deviceId: 'test-device-123',
+      }
+      localStorage.setItem('yearbird:cloud-sync-settings', JSON.stringify(stored))
+
+      const settings = getSyncSettings()
+      expect(settings.enabled).toBe(true)
+      expect(settings.lastSyncedAt).toBe(1234567890)
+      expect(settings.deviceId).toBe('test-device-123')
+    })
+
+    it('generates new deviceId if missing from stored settings', () => {
+      localStorage.setItem('yearbird:cloud-sync-settings', JSON.stringify({ enabled: true }))
+
+      const settings = getSyncSettings()
+      expect(settings.enabled).toBe(true)
+      expect(settings.deviceId).toBeDefined()
+      expect(settings.deviceId.length).toBeGreaterThan(0)
+    })
+
+    it('handles invalid JSON gracefully', () => {
+      localStorage.setItem('yearbird:cloud-sync-settings', 'not valid json')
+
+      const settings = getSyncSettings()
+      expect(settings.enabled).toBe(false)
+      expect(settings.lastSyncedAt).toBeNull()
+    })
+  })
+
+  describe('saveSyncSettings', () => {
+    it('saves settings to localStorage', () => {
+      const settings: CloudSyncSettings = {
+        enabled: true,
+        lastSyncedAt: 1234567890,
+        deviceId: 'test-device',
+      }
+
+      saveSyncSettings(settings)
+
+      const stored = JSON.parse(localStorage.getItem('yearbird:cloud-sync-settings') || '{}')
+      expect(stored.enabled).toBe(true)
+      expect(stored.lastSyncedAt).toBe(1234567890)
+      expect(stored.deviceId).toBe('test-device')
+    })
+  })
+
+  describe('isSyncEnabled', () => {
+    it('returns false when sync is disabled', () => {
+      expect(isSyncEnabled()).toBe(false)
+    })
+
+    it('returns true when sync is enabled and has drive scope', async () => {
+      const { hasDriveScope } = await import('./auth')
+      vi.mocked(hasDriveScope).mockReturnValue(true)
+
+      saveSyncSettings({
+        enabled: true,
+        lastSyncedAt: null,
+        deviceId: 'test',
+      })
+
+      expect(isSyncEnabled()).toBe(true)
+    })
+
+    it('returns false when enabled but no drive scope', async () => {
+      const { hasDriveScope } = await import('./auth')
+      vi.mocked(hasDriveScope).mockReturnValue(false)
+
+      saveSyncSettings({
+        enabled: true,
+        lastSyncedAt: null,
+        deviceId: 'test',
+      })
+
+      expect(isSyncEnabled()).toBe(false)
+    })
+  })
+
+  describe('getSyncStatus', () => {
+    it('returns disabled when sync is disabled', () => {
+      expect(getSyncStatus()).toBe('disabled')
+    })
+
+    it('returns needs-consent when enabled but no drive scope', async () => {
+      const { hasDriveScope } = await import('./auth')
+      vi.mocked(hasDriveScope).mockReturnValue(false)
+
+      saveSyncSettings({
+        enabled: true,
+        lastSyncedAt: null,
+        deviceId: 'test',
+      })
+
+      expect(getSyncStatus()).toBe('needs-consent')
+    })
+  })
+
+  describe('mergeConfigs', () => {
+    const baseConfig: CloudConfig = {
+      version: 1,
+      updatedAt: 1000,
+      deviceId: 'device-1',
+      filters: [],
+      disabledCalendars: [],
+      disabledBuiltInCategories: [],
+      customCategories: [],
+    }
+
+    it('uses remote arrays when remote is newer', () => {
+      const local: CloudConfig = {
+        ...baseConfig,
+        updatedAt: 1000,
+        filters: [{ id: '1', pattern: 'local-filter', createdAt: 1000 }],
+        disabledCalendars: ['cal-local'],
+      }
+
+      const remote: CloudConfig = {
+        ...baseConfig,
+        updatedAt: 2000,
+        filters: [{ id: '2', pattern: 'remote-filter', createdAt: 2000 }],
+        disabledCalendars: ['cal-remote'],
+      }
+
+      const merged = mergeConfigs(local, remote)
+
+      expect(merged.filters).toEqual(remote.filters)
+      expect(merged.disabledCalendars).toEqual(remote.disabledCalendars)
+    })
+
+    it('uses local arrays when local is newer', () => {
+      const local: CloudConfig = {
+        ...baseConfig,
+        updatedAt: 2000,
+        filters: [{ id: '1', pattern: 'local-filter', createdAt: 1000 }],
+        disabledCalendars: ['cal-local'],
+      }
+
+      const remote: CloudConfig = {
+        ...baseConfig,
+        updatedAt: 1000,
+        filters: [{ id: '2', pattern: 'remote-filter', createdAt: 500 }],
+        disabledCalendars: ['cal-remote'],
+      }
+
+      const merged = mergeConfigs(local, remote)
+
+      expect(merged.filters).toEqual(local.filters)
+      expect(merged.disabledCalendars).toEqual(local.disabledCalendars)
+    })
+
+    it('merges custom categories by ID with updatedAt precedence', () => {
+      const local: CloudConfig = {
+        ...baseConfig,
+        updatedAt: 1000,
+        customCategories: [
+          {
+            id: 'cat-1' as `custom-${string}`,
+            label: 'Local Category',
+            color: '#ff0000',
+            keywords: ['local'],
+            matchMode: 'any',
+            createdAt: 1000,
+            updatedAt: 2000, // Newer
+          },
+        ],
+      }
+
+      const remote: CloudConfig = {
+        ...baseConfig,
+        updatedAt: 2000,
+        customCategories: [
+          {
+            id: 'cat-1' as `custom-${string}`,
+            label: 'Remote Category',
+            color: '#00ff00',
+            keywords: ['remote'],
+            matchMode: 'any',
+            createdAt: 1000,
+            updatedAt: 1500, // Older
+          },
+        ],
+      }
+
+      const merged = mergeConfigs(local, remote)
+
+      expect(merged.customCategories).toHaveLength(1)
+      expect(merged.customCategories[0].label).toBe('Local Category')
+    })
+
+    it('handles deletions correctly (no resurrection)', () => {
+      // Local has deleted a filter (empty array)
+      const local: CloudConfig = {
+        ...baseConfig,
+        updatedAt: 2000,
+        filters: [],
+      }
+
+      // Remote still has the filter from before deletion
+      const remote: CloudConfig = {
+        ...baseConfig,
+        updatedAt: 1000,
+        filters: [{ id: '1', pattern: 'old-filter', createdAt: 500 }],
+      }
+
+      const merged = mergeConfigs(local, remote)
+
+      // Local is newer, so deleted filters should stay deleted
+      expect(merged.filters).toEqual([])
+    })
+  })
+
+  describe('applyCloudConfigToLocal', () => {
+    it('writes config data to respective localStorage keys', () => {
+      const config: CloudConfig = {
+        version: 1,
+        updatedAt: Date.now(),
+        deviceId: 'test-device',
+        filters: [{ id: '1', pattern: 'test', createdAt: 1000 }],
+        disabledCalendars: ['cal-1'],
+        disabledBuiltInCategories: ['work'],
+        customCategories: [],
+      }
+
+      applyCloudConfigToLocal(config)
+
+      const filters = JSON.parse(localStorage.getItem('yearbird:filters') || '[]')
+      expect(filters).toEqual(config.filters)
+
+      const disabledCalendars = JSON.parse(localStorage.getItem('yearbird:disabled-calendars') || '[]')
+      expect(disabledCalendars).toEqual(config.disabledCalendars)
+
+      const disabledCategories = JSON.parse(localStorage.getItem('yearbird:disabled-built-in-categories') || '[]')
+      expect(disabledCategories).toEqual(config.disabledBuiltInCategories)
+    })
+
+    it('removes localStorage keys when arrays are empty', () => {
+      // First set some data
+      localStorage.setItem('yearbird:filters', JSON.stringify([{ id: '1', pattern: 'test', createdAt: 1000 }]))
+      localStorage.setItem('yearbird:disabled-calendars', JSON.stringify(['cal-1']))
+
+      // Apply empty config
+      const config: CloudConfig = {
+        version: 1,
+        updatedAt: Date.now(),
+        deviceId: 'test-device',
+        filters: [],
+        disabledCalendars: [],
+        disabledBuiltInCategories: [],
+        customCategories: [],
+      }
+
+      applyCloudConfigToLocal(config)
+
+      expect(localStorage.getItem('yearbird:filters')).toBeNull()
+      expect(localStorage.getItem('yearbird:disabled-calendars')).toBeNull()
+    })
+  })
+
+  describe('clearSyncError', () => {
+    it('clears the sync error state', () => {
+      // Error state is module-level, so just verify the function doesn't throw
+      expect(() => clearSyncError()).not.toThrow()
+    })
+  })
+
+  describe('disableSync', () => {
+    it('sets enabled to false and clears lastSyncedAt', () => {
+      saveSyncSettings({
+        enabled: true,
+        lastSyncedAt: 1234567890,
+        deviceId: 'test-device',
+      })
+
+      disableSync()
+
+      const settings = getSyncSettings()
+      expect(settings.enabled).toBe(false)
+      expect(settings.lastSyncedAt).toBeNull()
+      expect(settings.deviceId).toBe('test-device')
+    })
+  })
+})

--- a/src/services/syncManager.ts
+++ b/src/services/syncManager.ts
@@ -1,0 +1,444 @@
+/**
+ * Sync Manager - Orchestrates synchronization between localStorage and Google Drive.
+ *
+ * Sync Strategy: "Drive as primary, localStorage as cache"
+ * - On app load: Fetch from Drive, update localStorage cache
+ * - On user action: Write to both (localStorage immediately, Drive async)
+ * - Offline: Fall back to localStorage, queue Drive writes for later
+ * - Drive unavailable: Graceful degradation, user notified
+ */
+
+import type { CustomCategoryId } from '../types/calendar'
+import type {
+  CloudConfig,
+  CloudCustomCategory,
+  CloudSyncSettings,
+  EventFilter,
+  SyncStatus,
+} from '../types/cloudConfig'
+import { hasDriveScope } from './auth'
+import { readCloudConfig, writeCloudConfig, checkDriveAccess } from './driveSync'
+import { getFilters } from './filters'
+import { getDisabledCalendars } from './calendarVisibility'
+import { getDisabledBuiltInCategories } from './builtInCategories'
+import { getCustomCategories } from './customCategories'
+
+const SYNC_SETTINGS_KEY = 'yearbird:cloud-sync-settings'
+/**
+ * Debounce duration for cloud sync writes.
+ * 2 seconds balances responsiveness with API quota conservation.
+ * Short enough for good UX, long enough to batch rapid changes.
+ */
+const SYNC_DEBOUNCE_MS = 2000
+
+let syncDebounceTimer: number | null = null
+let isSyncing = false
+let isWriting = false
+let needsAnotherWrite = false
+let lastSyncError: string | null = null
+
+/**
+ * Generate a unique device ID for conflict resolution
+ */
+function generateDeviceId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID()
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+/**
+ * Get cloud sync settings from localStorage
+ */
+export function getSyncSettings(): CloudSyncSettings {
+  try {
+    const raw = localStorage.getItem(SYNC_SETTINGS_KEY)
+    if (!raw) {
+      return {
+        enabled: false,
+        lastSyncedAt: null,
+        deviceId: generateDeviceId(),
+      }
+    }
+    const parsed = JSON.parse(raw) as Partial<CloudSyncSettings>
+    return {
+      enabled: parsed.enabled ?? false,
+      lastSyncedAt: parsed.lastSyncedAt ?? null,
+      deviceId: parsed.deviceId || generateDeviceId(),
+    }
+  } catch {
+    return {
+      enabled: false,
+      lastSyncedAt: null,
+      deviceId: generateDeviceId(),
+    }
+  }
+}
+
+/**
+ * Save cloud sync settings to localStorage
+ */
+export function saveSyncSettings(settings: CloudSyncSettings): void {
+  try {
+    localStorage.setItem(SYNC_SETTINGS_KEY, JSON.stringify(settings))
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+/**
+ * Check if cloud sync is enabled and ready
+ */
+export function isSyncEnabled(): boolean {
+  const settings = getSyncSettings()
+  return settings.enabled && hasDriveScope()
+}
+
+/**
+ * Get current sync status
+ */
+export function getSyncStatus(): SyncStatus {
+  const settings = getSyncSettings()
+
+  if (!settings.enabled) {
+    return 'disabled'
+  }
+
+  if (!hasDriveScope()) {
+    return 'needs-consent'
+  }
+
+  if (isSyncing) {
+    return 'syncing'
+  }
+
+  if (!navigator.onLine) {
+    return 'offline'
+  }
+
+  if (lastSyncError) {
+    return 'error'
+  }
+
+  return 'synced'
+}
+
+/**
+ * Get the last sync error message
+ */
+export function getLastSyncError(): string | null {
+  return lastSyncError
+}
+
+/**
+ * Clear the last sync error
+ */
+export function clearSyncError(): void {
+  lastSyncError = null
+}
+
+/**
+ * Build a CloudConfig from current localStorage state
+ */
+export function buildCloudConfigFromLocal(): CloudConfig {
+  const settings = getSyncSettings()
+
+  return {
+    version: 1,
+    updatedAt: Date.now(),
+    deviceId: settings.deviceId,
+    filters: getFilters(),
+    disabledCalendars: getDisabledCalendars(),
+    disabledBuiltInCategories: getDisabledBuiltInCategories(),
+    customCategories: getCustomCategories() as CloudCustomCategory[],
+  }
+}
+
+/**
+ * Merge local and remote configs.
+ * Strategy: Last-write-wins with timestamps, union for additive data.
+ */
+export function mergeConfigs(
+  local: CloudConfig,
+  remote: CloudConfig
+): CloudConfig {
+  const settings = getSyncSettings()
+
+  // Merge filters - union by pattern (case-insensitive dedupe)
+  const filterMap = new Map<string, EventFilter>()
+  for (const filter of [...remote.filters, ...local.filters]) {
+    const key = filter.pattern.toLowerCase()
+    const existing = filterMap.get(key)
+    if (!existing || filter.createdAt > existing.createdAt) {
+      filterMap.set(key, filter)
+    }
+  }
+
+  // Merge disabled calendars - union
+  const disabledCalendars = [...new Set([...remote.disabledCalendars, ...local.disabledCalendars])]
+
+  // Merge disabled built-in categories - remote wins (last-write-wins)
+  const disabledBuiltInCategories = remote.updatedAt >= local.updatedAt
+    ? remote.disabledBuiltInCategories
+    : local.disabledBuiltInCategories
+
+  // Merge custom categories - by ID, updatedAt wins
+  const categoryMap = new Map<CustomCategoryId, CloudCustomCategory>()
+  for (const cat of remote.customCategories) {
+    categoryMap.set(cat.id, cat)
+  }
+  for (const cat of local.customCategories) {
+    const existing = categoryMap.get(cat.id)
+    if (!existing || cat.updatedAt > existing.updatedAt) {
+      categoryMap.set(cat.id, cat)
+    }
+  }
+
+  return {
+    version: 1,
+    updatedAt: Date.now(),
+    deviceId: settings.deviceId,
+    filters: Array.from(filterMap.values()),
+    disabledCalendars,
+    disabledBuiltInCategories,
+    customCategories: Array.from(categoryMap.values()),
+  }
+}
+
+/**
+ * Apply cloud config to localStorage.
+ * This writes the config data to the respective localStorage keys.
+ */
+export function applyCloudConfigToLocal(config: CloudConfig): void {
+  try {
+    // Write filters
+    if (config.filters.length > 0) {
+      localStorage.setItem('yearbird:filters', JSON.stringify(config.filters))
+    } else {
+      localStorage.removeItem('yearbird:filters')
+    }
+
+    // Write disabled calendars
+    if (config.disabledCalendars.length > 0) {
+      localStorage.setItem('yearbird:disabled-calendars', JSON.stringify(config.disabledCalendars))
+    } else {
+      localStorage.removeItem('yearbird:disabled-calendars')
+    }
+
+    // Write disabled built-in categories
+    if (config.disabledBuiltInCategories.length > 0) {
+      localStorage.setItem('yearbird:disabled-built-in-categories', JSON.stringify(config.disabledBuiltInCategories))
+    } else {
+      localStorage.removeItem('yearbird:disabled-built-in-categories')
+    }
+
+    // Write custom categories
+    if (config.customCategories.length > 0) {
+      localStorage.setItem('yearbird:custom-categories', JSON.stringify({
+        version: 1,
+        categories: config.customCategories,
+      }))
+    } else {
+      localStorage.removeItem('yearbird:custom-categories')
+    }
+
+    // Update sync settings
+    const settings = getSyncSettings()
+    saveSyncSettings({
+      ...settings,
+      lastSyncedAt: Date.now(),
+    })
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+/**
+ * Perform a full sync with Google Drive.
+ * - Reads from Drive
+ * - Merges with local if both exist
+ * - Writes merged result back to both Drive and localStorage
+ */
+export async function performSync(): Promise<boolean> {
+  if (!isSyncEnabled()) {
+    return false
+  }
+
+  if (isSyncing) {
+    return false
+  }
+
+  isSyncing = true
+  lastSyncError = null
+
+  try {
+    // Check if we can access Drive
+    const canAccess = await checkDriveAccess()
+    if (!canAccess) {
+      if (!navigator.onLine) {
+        // Offline - not an error, just skip sync
+        return false
+      }
+      lastSyncError = 'Cannot access Google Drive'
+      return false
+    }
+
+    // Read from Drive
+    const remoteResult = await readCloudConfig()
+    if (!remoteResult.success) {
+      lastSyncError = remoteResult.error?.message || 'Failed to read from Drive'
+      return false
+    }
+
+    const localConfig = buildCloudConfigFromLocal()
+    let configToWrite: CloudConfig
+
+    if (remoteResult.data) {
+      // Merge local and remote
+      configToWrite = mergeConfigs(localConfig, remoteResult.data)
+    } else {
+      // No remote config - use local as initial upload
+      configToWrite = localConfig
+    }
+
+    // Write merged config to Drive
+    const writeResult = await writeCloudConfig(configToWrite)
+    if (!writeResult.success) {
+      lastSyncError = writeResult.error?.message || 'Failed to write to Drive'
+      return false
+    }
+
+    // Apply merged config to localStorage
+    applyCloudConfigToLocal(configToWrite)
+
+    return true
+  } catch (error) {
+    lastSyncError = error instanceof Error ? error.message : 'Sync failed'
+    return false
+  } finally {
+    isSyncing = false
+  }
+}
+
+/**
+ * Enable cloud sync.
+ * This should be called after the user grants Drive scope.
+ */
+export async function enableSync(): Promise<boolean> {
+  if (!hasDriveScope()) {
+    return false
+  }
+
+  const settings = getSyncSettings()
+  saveSyncSettings({
+    ...settings,
+    enabled: true,
+  })
+
+  // Perform initial sync
+  return performSync()
+}
+
+/**
+ * Disable cloud sync.
+ * Keeps local data but stops syncing to Drive.
+ */
+export function disableSync(): void {
+  const settings = getSyncSettings()
+  saveSyncSettings({
+    ...settings,
+    enabled: false,
+    lastSyncedAt: null,
+  })
+
+  lastSyncError = null
+}
+
+/**
+ * Schedule a debounced sync.
+ * Call this after any local data change to sync to Drive.
+ *
+ * Uses isWriting/needsAnotherWrite flags to handle rapid changes:
+ * - If a write is in progress and new changes come in, we flag for another write
+ * - After the current write completes, we check if another write is needed
+ * - This prevents race conditions where changes during a write are lost
+ */
+export function scheduleSyncToCloud(): void {
+  if (!isSyncEnabled()) {
+    return
+  }
+
+  if (syncDebounceTimer !== null) {
+    window.clearTimeout(syncDebounceTimer)
+  }
+
+  // If we're currently writing, flag that we need another write after
+  if (isWriting) {
+    needsAnotherWrite = true
+    return
+  }
+
+  syncDebounceTimer = window.setTimeout(async () => {
+    syncDebounceTimer = null
+
+    if (!navigator.onLine) {
+      // Queue for later when online
+      return
+    }
+
+    await performDebouncedWrite()
+  }, SYNC_DEBOUNCE_MS)
+}
+
+/**
+ * Perform the actual debounced write to Drive.
+ * Handles the isWriting flag and checks for queued writes.
+ */
+async function performDebouncedWrite(): Promise<void> {
+  if (isWriting) {
+    needsAnotherWrite = true
+    return
+  }
+
+  isWriting = true
+  needsAnotherWrite = false
+
+  try {
+    const localConfig = buildCloudConfigFromLocal()
+    const writeResult = await writeCloudConfig(localConfig)
+
+    if (!writeResult.success) {
+      lastSyncError = writeResult.error?.message || 'Failed to sync'
+      console.warn('Cloud sync failed:', lastSyncError)
+    } else {
+      lastSyncError = null
+      const settings = getSyncSettings()
+      saveSyncSettings({
+        ...settings,
+        lastSyncedAt: Date.now(),
+      })
+    }
+  } finally {
+    isWriting = false
+
+    // If changes occurred during the write, schedule another write
+    if (needsAnotherWrite) {
+      needsAnotherWrite = false
+      scheduleSyncToCloud()
+    }
+  }
+}
+
+/**
+ * Handle coming back online - sync queued changes.
+ */
+export function handleOnline(): void {
+  if (isSyncEnabled()) {
+    performSync()
+  }
+}
+
+// Set up online listener
+if (typeof window !== 'undefined') {
+  window.addEventListener('online', handleOnline)
+}

--- a/src/types/cloudConfig.ts
+++ b/src/types/cloudConfig.ts
@@ -1,0 +1,69 @@
+import type { BuiltInCategory, CustomCategoryId } from './calendar'
+import type { CategoryMatchMode } from './categories'
+
+/**
+ * Event filter pattern for hiding specific events
+ */
+export interface EventFilter {
+  id: string
+  pattern: string
+  createdAt: number
+}
+
+/**
+ * Custom category definition (matches existing CustomCategory type)
+ */
+export interface CloudCustomCategory {
+  id: CustomCategoryId
+  label: string
+  color: string
+  keywords: string[]
+  matchMode: CategoryMatchMode
+  createdAt: number
+  updatedAt: number
+}
+
+/**
+ * Cloud configuration stored in Google Drive appDataFolder.
+ * Single file for atomic updates and simpler sync logic.
+ */
+export interface CloudConfig {
+  /** Schema version for future migrations */
+  version: 1
+  /** Timestamp of last update (ms since epoch) */
+  updatedAt: number
+  /** Device identifier that last wrote this config */
+  deviceId: string
+
+  /** Hidden event patterns */
+  filters: EventFilter[]
+  /** Disabled calendar IDs */
+  disabledCalendars: string[]
+  /** Disabled built-in category names */
+  disabledBuiltInCategories: BuiltInCategory[]
+  /** User-defined category rules */
+  customCategories: CloudCustomCategory[]
+}
+
+/**
+ * Cloud sync settings stored in localStorage
+ */
+export interface CloudSyncSettings {
+  /** Whether cloud sync is enabled */
+  enabled: boolean
+  /** Timestamp of last successful sync */
+  lastSyncedAt: number | null
+  /** Device ID for conflict resolution */
+  deviceId: string
+}
+
+/**
+ * Status of the cloud sync feature
+ */
+export type SyncStatus =
+  | 'disabled'
+  | 'synced'
+  | 'syncing'
+  | 'offline'
+  | 'error'
+  | 'needs-consent'

--- a/src/types/google.d.ts
+++ b/src/types/google.d.ts
@@ -1,12 +1,23 @@
 declare namespace google.accounts.oauth2 {
   interface TokenClient {
-    requestAccessToken(): void
+    requestAccessToken(options?: RequestAccessTokenOptions): void
+  }
+
+  interface RequestAccessTokenOptions {
+    /** Prompts the user for consent. Use 'consent' to force re-consent for incremental scopes. */
+    prompt?: '' | 'none' | 'consent' | 'select_account'
+    /** Hint for email address to pre-fill */
+    hint?: string
+    /** State parameter for OAuth flow */
+    state?: string
   }
 
   interface TokenClientConfig {
     client_id: string
     scope: string
     callback: (response: TokenResponse) => void
+    /** Error callback for access denied or popup closed */
+    error_callback?: (error: TokenError) => void
   }
 
   interface TokenResponse {
@@ -15,8 +26,17 @@ declare namespace google.accounts.oauth2 {
     scope: string
     token_type: string
     error?: string
+    error_description?: string
+    error_uri?: string
+  }
+
+  interface TokenError {
+    type: 'popup_failed_to_open' | 'popup_closed' | 'unknown'
+    message?: string
   }
 
   function initTokenClient(config: TokenClientConfig): TokenClient
   function revoke(token: string, callback: () => void): void
+  function hasGrantedAllScopes(response: TokenResponse, ...scopes: string[]): boolean
+  function hasGrantedAnyScope(response: TokenResponse, ...scopes: string[]): boolean
 }


### PR DESCRIPTION
## Summary

- Implements optional cloud sync using Google Drive's appDataFolder API for cross-device sync of user preferences
- Uses "Drive as primary, localStorage as cache" strategy with graceful offline fallback
- Adds incremental OAuth consent (only requests `drive.appdata` scope when user enables sync)

## Changes

| Category | Files | Description |
|----------|-------|-------------|
| 🆕 Services | `driveSync.ts`, `syncManager.ts` | Drive API operations and sync orchestration |
| 🆕 Components | `CloudSyncToggle.tsx`, `useCloudSync.ts` | UI toggle with status indicators and React hook |
| 📝 Auth | `auth.ts`, `google.d.ts` | Added `drive.appdata` scope handling |
| 🔄 Hooks | `useFilters`, `useCalendarVisibility`, `useBuiltInCategories`, `useCustomCategories` | Added `scheduleSyncToCloud()` calls |
| 📖 Docs | `ARCHITECTURE.md`, `GOOGLE_OAUTH.md` | Updated with sync flow diagrams and cloud sync section |

## Features

- ✅ Debounced async writes (2s) to batch rapid changes
- ✅ Race condition handling with isWriting/needsAnotherWrite flags
- ✅ Last-write-wins merge for conflicts, union for additive data
- ✅ Offline detection with automatic retry when online
- ✅ Status indicators (synced, syncing, offline, error, needs-consent)
- ✅ Accessible SVG icons with `aria-hidden="true"`

## Test plan

- [ ] Enable cloud sync in Filter panel → should prompt for Google consent
- [ ] Grant consent → should show "Synced" status
- [ ] Add a filter → should debounce and sync after 2s
- [ ] Disable network → should show "Offline" status
- [ ] Re-enable network → should auto-sync
- [ ] Sign in on another device → preferences should appear

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)