### PR TITLE
fix: make Cloud Sync ON by default

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -97,7 +97,7 @@ export function initializeAuth(onSuccess: (response: google.accounts.oauth2.Toke
 
   tokenClient = google.accounts.oauth2.initTokenClient({
     client_id: CLIENT_ID,
-    scope: SCOPES,
+    scope: ALL_SCOPES, // Request calendar + drive.appdata upfront for Cloud Sync
     callback: onSuccess,
   })
   return true


### PR DESCRIPTION
## Summary
- Cloud Sync is now **ON by default** when user logs in with Google OAuth
- New devices with empty local settings **inherit remote settings from Drive** instead of overwriting them with empty defaults  
- Users can still opt-out via the toggle in the filter panel

## Problem
When enabling Cloud Sync on a TV after already using it on a MacBook, the TV's empty localStorage would overwrite the MacBook's settings in Drive because:
1. The TV builds a local config with `updatedAt = Date.now()`
2. The MacBook's config in Drive has `updatedAt = earlier timestamp`
3. Last-write-wins logic saw TV as "newer" and wiped the settings

## Solution
1. **Request ALL_SCOPES upfront**: OAuth now requests `calendar.readonly + drive.appdata` during initial sign-in (not incremental)
2. **Default-on sync**: Sync is enabled by default when user has drive scope, unless explicitly disabled
3. **Empty-local detection**: Added `isEmptyConfig()` to detect when local is empty/default and prefer remote settings

## Test plan
- [x] All 436 tests pass
- [x] Typecheck passes
- [x] Lint passes
- [ ] Manual test: Sign in on fresh device, verify settings from Drive are applied
- [ ] Manual test: Disable sync, verify the opt-out persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)