### PR TITLE
feat: add day summary popover with timed events and loading screen

### DIFF
--- a/e2e/layout.spec.ts
+++ b/e2e/layout.spec.ts
@@ -29,7 +29,7 @@ test.describe('layout snapshots (desktop)', () => {
 
   test('event tooltip', async ({ page }) => {
     const bar = page.getByRole('button', { name: 'Executive strategy review' }).first()
-    await bar.hover()
+    await bar.click()
     await expect(
       page.getByRole('tooltip', { name: 'Executive strategy review details' })
     ).toBeVisible()
@@ -76,7 +76,7 @@ test.describe('marketing snapshots (1280)', () => {
 
   test('event tooltip', async ({ page }) => {
     const bar = page.getByRole('button', { name: 'Executive strategy review' }).first()
-    await bar.hover()
+    await bar.click()
     await expect(
       page.getByRole('tooltip', { name: 'Executive strategy review details' })
     ).toBeVisible()
@@ -138,7 +138,7 @@ test.describe('marketing snapshots (1920)', () => {
 
   test('event tooltip', async ({ page }) => {
     const bar = page.getByRole('button', { name: 'Executive strategy review' }).first()
-    await bar.hover()
+    await bar.click()
     await expect(
       page.getByRole('tooltip', { name: 'Executive strategy review details' })
     ).toBeVisible()

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@tailwindcss/vite": "^4.1.18",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.10.1",
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.7",
@@ -2152,6 +2153,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
-    "@tailwindcss/vite": "^4.1.18",
     "@playwright/test": "^1.53.0",
+    "@tailwindcss/vite": "^4.1.18",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.10.1",
     "@types/react": "^18.3.27",
     "@types/react-dom": "^18.3.7",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -115,7 +115,7 @@ beforeEach(() => {
     resetToDefaults: vi.fn(),
   })
   useCalendarListMock.mockReturnValue({
-    calendars: [],
+    calendars: [{ id: 'primary', summary: 'Test Calendar', primary: true }],
     isLoading: false,
     error: null,
     refetch: vi.fn(),
@@ -351,10 +351,12 @@ test('allows hiding events from the event bars', async () => {
 
   render(<App />)
 
-  fireEvent.mouseEnter(screen.getByRole('button', { name: 'A' }), {
+  // Click event bar to show tooltip
+  fireEvent.click(screen.getByRole('button', { name: 'A' }), {
     clientX: 140,
     clientY: 90,
   })
+  // Wait for tooltip and click hide button
   fireEvent.click(await screen.findByRole('button', { name: /hide events like a/i }))
   expect(addFilter).toHaveBeenCalledWith('A')
 })

--- a/src/components/CalendarLoadingScreen.tsx
+++ b/src/components/CalendarLoadingScreen.tsx
@@ -1,0 +1,59 @@
+interface CalendarLoadingScreenProps {
+  /** When true, triggers fade-out animation */
+  isHiding?: boolean
+  /** Called when fade-out animation completes */
+  onHidden?: () => void
+}
+
+/**
+ * Full-screen loading screen shown after authentication while calendars load.
+ * Blocks the entire screen to prevent FOUC during initial data fetch.
+ *
+ * Uses a fade-out animation when hiding to:
+ * 1. Provide a polished transition
+ * 2. Give the browser time to paint the content underneath
+ */
+export function CalendarLoadingScreen({ isHiding = false, onHidden }: CalendarLoadingScreenProps) {
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-white transition-opacity duration-300 ${
+        isHiding ? 'opacity-0' : 'opacity-100'
+      }`}
+      onTransitionEnd={(e) => {
+        // Only respond to opacity transition on this element
+        if (e.propertyName === 'opacity' && isHiding && onHidden) {
+          onHidden()
+        }
+      }}
+    >
+      <div className="flex flex-col items-center gap-6">
+        {/* Logo with glow effect */}
+        <div className="relative">
+          <div className="absolute -inset-8 rounded-full bg-amber-100/60 blur-3xl" />
+          <img
+            src="/eagle.svg"
+            alt="Yearbird"
+            className="relative h-16 w-16 float-bird"
+          />
+        </div>
+
+        {/* App name */}
+        <h1 className="text-2xl font-semibold tracking-tight text-zinc-900">
+          Yearbird
+        </h1>
+
+        {/* Loading indicator */}
+        <div className="flex flex-col items-center gap-3">
+          <div className="flex items-center gap-1.5">
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-400" style={{ animationDelay: '0ms' }} />
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-400" style={{ animationDelay: '150ms' }} />
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-400" style={{ animationDelay: '300ms' }} />
+          </div>
+          <p className="text-xs uppercase tracking-[0.25em] text-zinc-400">
+            Loading your calendars
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/calendar/DayColumnView.test.tsx
+++ b/src/components/calendar/DayColumnView.test.tsx
@@ -1,0 +1,190 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { DayColumnView } from './DayColumnView'
+import type { YearbirdEvent } from '../../types/calendar'
+import type { CategoryConfig } from '../../types/categories'
+
+const buildEvent = (overrides: Partial<YearbirdEvent> = {}): YearbirdEvent => ({
+  id: '1',
+  title: 'Meeting',
+  startDate: '2025-02-10',
+  endDate: '2025-02-10',
+  isAllDay: false,
+  isMultiDay: false,
+  isSingleDayTimed: true,
+  durationDays: 1,
+  googleLink: '',
+  category: 'work',
+  color: '#8B5CF6',
+  startTime: '09:00',
+  endTime: '10:00',
+  startTimeMinutes: 540, // 9 * 60
+  endTimeMinutes: 600, // 10 * 60
+  ...overrides,
+})
+
+const defaultCategories: CategoryConfig[] = [
+  { category: 'work', label: 'Work', keywords: [], color: '#8B5CF6' },
+  { category: 'personal', label: 'Personal', keywords: [], color: '#10B981' },
+]
+
+describe('DayColumnView', () => {
+  it('renders "No timed events" when events array is empty', () => {
+    render(<DayColumnView events={[]} categories={defaultCategories} />)
+
+    expect(screen.getByText('No timed events')).toBeInTheDocument()
+  })
+
+  it('renders "No timed events" when events lack time data', () => {
+    const eventWithoutTime = buildEvent({
+      startTimeMinutes: undefined,
+      endTimeMinutes: undefined,
+    })
+
+    render(<DayColumnView events={[eventWithoutTime]} categories={defaultCategories} />)
+
+    expect(screen.getByText('No timed events')).toBeInTheDocument()
+  })
+
+  it('renders event title and time range', () => {
+    const event = buildEvent({ title: 'Team Standup' })
+
+    render(<DayColumnView events={[event]} categories={defaultCategories} />)
+
+    expect(screen.getByText('Team Standup')).toBeInTheDocument()
+  })
+
+  it('renders multiple events at different times', () => {
+    const events = [
+      buildEvent({
+        id: '1',
+        title: 'Morning Meeting',
+        startTimeMinutes: 540,
+        endTimeMinutes: 600,
+      }),
+      buildEvent({
+        id: '2',
+        title: 'Lunch',
+        startTimeMinutes: 720,
+        endTimeMinutes: 780,
+      }),
+      buildEvent({
+        id: '3',
+        title: 'Afternoon Review',
+        startTimeMinutes: 840,
+        endTimeMinutes: 900,
+      }),
+    ]
+
+    render(<DayColumnView events={events} categories={defaultCategories} />)
+
+    expect(screen.getByText('Morning Meeting')).toBeInTheDocument()
+    expect(screen.getByText('Lunch')).toBeInTheDocument()
+    expect(screen.getByText('Afternoon Review')).toBeInTheDocument()
+  })
+
+  it('handles overlapping events by positioning them side by side', () => {
+    const events = [
+      buildEvent({
+        id: '1',
+        title: 'Meeting A',
+        startTimeMinutes: 540,
+        endTimeMinutes: 660, // 9-11 AM
+      }),
+      buildEvent({
+        id: '2',
+        title: 'Meeting B',
+        startTimeMinutes: 600,
+        endTimeMinutes: 720, // 10 AM - 12 PM (overlaps with A)
+      }),
+    ]
+
+    const { container } = render(
+      <DayColumnView events={events} categories={defaultCategories} />
+    )
+
+    // Both events should be rendered
+    expect(screen.getByText('Meeting A')).toBeInTheDocument()
+    expect(screen.getByText('Meeting B')).toBeInTheDocument()
+
+    // Check that overlapping events have reduced width (50% each)
+    const eventButtons = container.querySelectorAll('button')
+    expect(eventButtons).toHaveLength(2)
+    // Each should have width: calc(50% - 2px)
+    expect(eventButtons[0]).toHaveStyle({ width: 'calc(50% - 2px)' })
+    expect(eventButtons[1]).toHaveStyle({ width: 'calc(50% - 2px)' })
+  })
+
+  it('calls onEventClick when event is clicked', () => {
+    const onEventClick = vi.fn()
+    const event = buildEvent({ title: 'Clickable Meeting' })
+
+    render(
+      <DayColumnView
+        events={[event]}
+        categories={defaultCategories}
+        onEventClick={onEventClick}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Clickable Meeting'), {
+      clientX: 100,
+      clientY: 200,
+    })
+
+    expect(onEventClick).toHaveBeenCalledWith(event, { x: 100, y: 200 })
+  })
+
+  it('renders time axis with hour labels', () => {
+    const event = buildEvent()
+
+    render(<DayColumnView events={[event]} categories={defaultCategories} />)
+
+    // Check for some hour labels (6 AM through 10 PM range)
+    expect(screen.getByText('9 AM')).toBeInTheDocument()
+    expect(screen.getByText('12 PM')).toBeInTheDocument()
+    expect(screen.getByText('3 PM')).toBeInTheDocument()
+  })
+
+  it('uses event color from calendar or category', () => {
+    const eventWithCalendarColor = buildEvent({
+      calendarColor: '#FF5733',
+    })
+
+    const { container } = render(
+      <DayColumnView events={[eventWithCalendarColor]} categories={defaultCategories} />
+    )
+
+    const eventButton = container.querySelector('button')
+    expect(eventButton).toHaveStyle({ borderLeftColor: '#FF5733' })
+  })
+
+  it('falls back to category color when no calendar color', () => {
+    const event = buildEvent({
+      calendarColor: undefined,
+      category: 'work',
+    })
+
+    const { container } = render(
+      <DayColumnView events={[event]} categories={defaultCategories} />
+    )
+
+    const eventButton = container.querySelector('button')
+    expect(eventButton).toHaveStyle({ borderLeftColor: '#8B5CF6' })
+  })
+
+  it('shows title with tooltip for full event info', () => {
+    const event = buildEvent({
+      title: 'Important Meeting',
+      startTime: '14:00',
+      endTime: '15:30',
+    })
+
+    const { container } = render(
+      <DayColumnView events={[event]} categories={defaultCategories} />
+    )
+
+    const eventButton = container.querySelector('button')
+    expect(eventButton).toHaveAttribute('title', '14:00 - 15:30: Important Meeting')
+  })
+})

--- a/src/components/calendar/DayColumnView.tsx
+++ b/src/components/calendar/DayColumnView.tsx
@@ -1,0 +1,216 @@
+import { useMemo } from 'react'
+import type { YearbirdEvent } from '../../types/calendar'
+import type { CategoryConfig } from '../../types/categories'
+import { getCategoryConfig } from '../../utils/categorize'
+
+interface DayColumnViewProps {
+  events: YearbirdEvent[]
+  categories: CategoryConfig[]
+  onEventClick?: (event: YearbirdEvent, position: { x: number; y: number }) => void
+}
+
+// Layout constants
+const HOUR_HEIGHT = 40 // px per hour
+const START_HOUR = 6 // 6 AM
+const END_HOUR = 22 // 10 PM
+const VISIBLE_HOURS = END_HOUR - START_HOUR
+const TIME_AXIS_WIDTH = 40 // px
+
+interface PositionedEvent {
+  event: YearbirdEvent
+  top: number
+  height: number
+  left: number
+  width: number
+  column: number
+  totalColumns: number
+}
+
+/**
+ * Groups overlapping events and assigns column positions.
+ * Events that overlap in time are placed side by side.
+ */
+function calculateEventPositions(events: YearbirdEvent[]): PositionedEvent[] {
+  // Filter to events with valid time data
+  const timedEvents = events.filter(
+    (e) => e.startTimeMinutes !== undefined && e.endTimeMinutes !== undefined
+  )
+
+  if (timedEvents.length === 0) return []
+
+  // Sort by start time, then by duration (longer events first)
+  const sorted = [...timedEvents].sort((a, b) => {
+    const startDiff = (a.startTimeMinutes ?? 0) - (b.startTimeMinutes ?? 0)
+    if (startDiff !== 0) return startDiff
+    // Longer events go first (they get column 0)
+    const aDuration = (a.endTimeMinutes ?? 0) - (a.startTimeMinutes ?? 0)
+    const bDuration = (b.endTimeMinutes ?? 0) - (b.startTimeMinutes ?? 0)
+    return bDuration - aDuration
+  })
+
+  // Group overlapping events
+  const groups: YearbirdEvent[][] = []
+  let currentGroup: YearbirdEvent[] = []
+  let groupEnd = 0
+
+  for (const event of sorted) {
+    const eventStart = event.startTimeMinutes ?? 0
+    const eventEnd = event.endTimeMinutes ?? eventStart + 60
+
+    if (currentGroup.length === 0 || eventStart < groupEnd) {
+      // Event overlaps with current group
+      currentGroup.push(event)
+      groupEnd = Math.max(groupEnd, eventEnd)
+    } else {
+      // Start new group
+      if (currentGroup.length > 0) {
+        groups.push(currentGroup)
+      }
+      currentGroup = [event]
+      groupEnd = eventEnd
+    }
+  }
+
+  if (currentGroup.length > 0) {
+    groups.push(currentGroup)
+  }
+
+  // Assign columns within each group
+  const positioned: PositionedEvent[] = []
+
+  for (const group of groups) {
+    const totalColumns = group.length
+    const columnWidth = 100 / totalColumns
+
+    group.forEach((event, index) => {
+      const startMinutes = event.startTimeMinutes ?? 0
+      const endMinutes = event.endTimeMinutes ?? startMinutes + 60
+
+      // Calculate position relative to visible hours
+      const startOffset = startMinutes - START_HOUR * 60
+      const duration = Math.max(15, endMinutes - startMinutes) // Min 15 min for visibility
+
+      positioned.push({
+        event,
+        top: (startOffset / 60) * HOUR_HEIGHT,
+        height: (duration / 60) * HOUR_HEIGHT,
+        left: index * columnWidth,
+        width: columnWidth,
+        column: index,
+        totalColumns,
+      })
+    })
+  }
+
+  return positioned
+}
+
+/**
+ * Formats hour number to display string (e.g., 9 -> "9 AM", 14 -> "2 PM")
+ */
+function formatHour(hour: number): string {
+  if (hour === 0) return '12 AM'
+  if (hour === 12) return '12 PM'
+  if (hour < 12) return `${hour} AM`
+  return `${hour - 12} PM`
+}
+
+/**
+ * DayColumnView displays timed events in a Google Calendar-style day column.
+ *
+ * Events are positioned vertically based on their start time, with heights
+ * proportional to duration. Overlapping events are displayed side by side.
+ */
+export function DayColumnView({ events, categories, onEventClick }: DayColumnViewProps) {
+  const hours = useMemo(
+    () => Array.from({ length: VISIBLE_HOURS }, (_, i) => START_HOUR + i),
+    []
+  )
+
+  const positionedEvents = useMemo(() => calculateEventPositions(events), [events])
+
+  const handleEventClick = (event: YearbirdEvent, e: React.MouseEvent<HTMLButtonElement>) => {
+    if (onEventClick) {
+      onEventClick(event, { x: e.clientX, y: e.clientY })
+    }
+  }
+
+  if (positionedEvents.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-6 text-sm text-zinc-400">
+        No timed events
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="relative flex"
+      style={{ height: `${VISIBLE_HOURS * HOUR_HEIGHT}px` }}
+    >
+      {/* Time axis */}
+      <div
+        className="sticky left-0 z-10 shrink-0 bg-white"
+        style={{ width: `${TIME_AXIS_WIDTH}px` }}
+      >
+        {hours.map((hour) => (
+          <div
+            key={hour}
+            className="relative border-t border-zinc-100 text-right"
+            style={{ height: `${HOUR_HEIGHT}px` }}
+          >
+            <span className="absolute -top-2 right-1 text-[10px] text-zinc-400">
+              {formatHour(hour)}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Event column */}
+      <div className="relative flex-1">
+        {/* Hour grid lines */}
+        {hours.map((hour) => (
+          <div
+            key={hour}
+            className="border-t border-zinc-100"
+            style={{ height: `${HOUR_HEIGHT}px` }}
+          />
+        ))}
+
+        {/* Events */}
+        {positionedEvents.map((positioned) => {
+          const { event, top, height, left, width } = positioned
+          const category = getCategoryConfig(event.category, categories)
+          const eventColor = event.calendarColor ?? category.color
+
+          return (
+            <button
+              key={event.id}
+              type="button"
+              onClick={(e) => handleEventClick(event, e)}
+              className="absolute overflow-hidden rounded border-l-2 bg-opacity-20 px-1 py-0.5 text-left transition hover:bg-opacity-30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-sky-500"
+              style={{
+                top: `${top}px`,
+                height: `${Math.max(height, 18)}px`,
+                left: `${left}%`,
+                width: `calc(${width}% - 2px)`,
+                borderLeftColor: eventColor,
+                backgroundColor: `${eventColor}20`,
+              }}
+              title={`${event.startTime} - ${event.endTime}: ${event.title}`}
+            >
+              <div className="line-clamp-2 text-xs font-medium text-zinc-800">
+                {event.title}
+              </div>
+              {height >= 32 && (
+                <div className="text-[10px] text-zinc-500">
+                  {event.startTime} - {event.endTime}
+                </div>
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/calendar/DaySummaryPopover.test.tsx
+++ b/src/components/calendar/DaySummaryPopover.test.tsx
@@ -1,0 +1,172 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { YearbirdEvent } from '../../types/calendar'
+import type { CategoryConfig } from '../../types/categories'
+import { DaySummaryPopover } from './DaySummaryPopover'
+
+/**
+ * Creates a mock YearbirdEvent with sensible defaults.
+ * Override any properties as needed for specific test cases.
+ */
+const createMockEvent = (overrides?: Partial<YearbirdEvent>): YearbirdEvent => ({
+  id: 'test-1',
+  title: 'Test Event',
+  startDate: '2025-01-15',
+  endDate: '2025-01-15',
+  isAllDay: true,
+  isMultiDay: false,
+  isSingleDayTimed: false,
+  durationDays: 1,
+  googleLink: 'https://calendar.google.com/calendar/event?eid=test123',
+  category: 'work',
+  color: '#8B5CF6',
+  calendarId: 'primary',
+  calendarName: 'Work Calendar',
+  calendarColor: '#38BDF8',
+  ...overrides,
+})
+
+/**
+ * Creates an array of mock events for testing overflow behavior.
+ */
+const createMockEvents = (count: number): YearbirdEvent[] =>
+  Array.from({ length: count }, (_, i) =>
+    createMockEvent({
+      id: `event-${i + 1}`,
+      title: `Event ${i + 1}`,
+    })
+  )
+
+const mockCategories: CategoryConfig[] = [
+  { category: 'work', color: '#8B5CF6', label: 'Work', keywords: [] },
+  { category: 'personal', color: '#22C55E', label: 'Personal', keywords: [] },
+]
+
+const defaultProps = {
+  date: new Date(2025, 0, 15),
+  events: [createMockEvent()],
+  categories: mockCategories,
+  googleCalendarCreateUrl: 'https://calendar.google.com/calendar/r/eventedit?dates=20250115/20250116',
+  googleCalendarDayUrl: 'https://calendar.google.com/calendar/r/day/2025/1/15',
+  children: <button>Trigger</button>,
+}
+
+describe('DaySummaryPopover', () => {
+  it('renders date header correctly', async () => {
+    render(<DaySummaryPopover {...defaultProps} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('January 15, 2025')).toBeInTheDocument()
+    })
+  })
+
+  it('displays all events when 6 or fewer', async () => {
+    const events = createMockEvents(4)
+    render(<DaySummaryPopover {...defaultProps} events={events} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Event 1')).toBeInTheDocument()
+      expect(screen.getByText('Event 2')).toBeInTheDocument()
+      expect(screen.getByText('Event 3')).toBeInTheDocument()
+      expect(screen.getByText('Event 4')).toBeInTheDocument()
+      expect(screen.queryByText(/more/)).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows overflow message when more than 6 events', async () => {
+    const events = createMockEvents(9)
+    render(<DaySummaryPopover {...defaultProps} events={events} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }))
+
+    await waitFor(() => {
+      // Should show first 6 events
+      expect(screen.getByText('Event 1')).toBeInTheDocument()
+      expect(screen.getByText('Event 6')).toBeInTheDocument()
+      // Should not show 7th event
+      expect(screen.queryByText('Event 7')).not.toBeInTheDocument()
+      // Should show overflow link
+      expect(screen.getByText(/\+3 more — View all in Google/)).toBeInTheDocument()
+    })
+  })
+
+  it('calls onEventClick when event row is clicked', async () => {
+    const onEventClick = vi.fn()
+    render(<DaySummaryPopover {...defaultProps} onEventClick={onEventClick} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }))
+
+    await waitFor(() => {
+      const eventButton = screen.getByRole('button', { name: 'Test Event' })
+      expect(eventButton).toBeInTheDocument()
+      fireEvent.click(eventButton)
+      expect(onEventClick).toHaveBeenCalledWith(
+        defaultProps.events[0],
+        expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) })
+      )
+    })
+  })
+
+  it('renders "Open Day" button with correct URL', async () => {
+    render(<DaySummaryPopover {...defaultProps} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }))
+
+    await waitFor(() => {
+      const openDayLink = screen.getByRole('link', { name: /Open Day/i })
+      expect(openDayLink).toHaveAttribute('href', defaultProps.googleCalendarDayUrl)
+      expect(openDayLink).toHaveAttribute('target', '_blank')
+    })
+  })
+
+  it('renders "New Event" button with correct URL', async () => {
+    render(<DaySummaryPopover {...defaultProps} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }))
+
+    await waitFor(() => {
+      const newEventLink = screen.getByRole('link', { name: /New Event/i })
+      expect(newEventLink).toHaveAttribute('href', defaultProps.googleCalendarCreateUrl)
+      expect(newEventLink).toHaveAttribute('target', '_blank')
+    })
+  })
+
+  it('renders close button with aria-label', async () => {
+    render(<DaySummaryPopover {...defaultProps} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Close popover/i })).toBeInTheDocument()
+    })
+  })
+
+  it('shows "No events" message when events array is empty', async () => {
+    render(<DaySummaryPopover {...defaultProps} events={[]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('No events')).toBeInTheDocument()
+    })
+  })
+
+  it('uses event calendarColor when available', async () => {
+    const eventWithCalendarColor = createMockEvent({ calendarColor: '#FF0000' })
+    render(<DaySummaryPopover {...defaultProps} events={[eventWithCalendarColor]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }))
+
+    await waitFor(() => {
+      // The color dot should use calendarColor
+      const listItems = screen.getAllByRole('listitem')
+      expect(listItems.length).toBeGreaterThan(0)
+      const colorDot = within(listItems[0]).getByRole('button').querySelector('span[aria-hidden="true"]')
+      expect(colorDot).toHaveStyle({ backgroundColor: '#FF0000' })
+    })
+  })
+})

--- a/src/components/calendar/DaySummaryPopover.tsx
+++ b/src/components/calendar/DaySummaryPopover.tsx
@@ -1,0 +1,207 @@
+import { Popover, PopoverButton, PopoverPanel, CloseButton } from '@headlessui/react'
+import type { YearbirdEvent } from '../../types/calendar'
+import type { CategoryConfig } from '../../types/categories'
+import { ExternalLinkIcon } from '../icons/ExternalLinkIcon'
+import { getCategoryConfig } from '../../utils/categorize'
+import { DayColumnView } from './DayColumnView'
+
+interface DaySummaryPopoverProps {
+  date: Date
+  /** All-day and multi-day events for this day */
+  events: YearbirdEvent[]
+  /** Single-day timed events (meetings, appointments) for column view */
+  timedEvents?: YearbirdEvent[]
+  categories: CategoryConfig[]
+  googleCalendarCreateUrl: string
+  googleCalendarDayUrl: string
+  children: React.ReactNode
+  onEventClick?: (event: YearbirdEvent, position: { x: number; y: number }) => void
+}
+
+const MAX_VISIBLE_EVENTS = 6
+const DATE_FORMAT: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric', year: 'numeric' }
+
+/**
+ * DaySummaryPopover displays a list of events for a clicked day cell.
+ *
+ * Usage:
+ * ```tsx
+ * <DaySummaryPopover
+ *   date={new Date(2025, 0, 15)}
+ *   events={eventsForDay}
+ *   categories={categoryConfigs}
+ *   googleCalendarCreateUrl="https://calendar.google.com/calendar/r/eventedit?dates=20250115/20250116"
+ *   googleCalendarDayUrl="https://calendar.google.com/calendar/r/day/2025/1/15"
+ *   onEventClick={(event, pos) => showTooltip(event, pos)}
+ * >
+ *   <span className="day-cell">15</span>
+ * </DaySummaryPopover>
+ * ```
+ */
+export function DaySummaryPopover({
+  date,
+  events,
+  timedEvents,
+  categories,
+  googleCalendarCreateUrl,
+  googleCalendarDayUrl,
+  children,
+  onEventClick,
+}: DaySummaryPopoverProps) {
+  const formattedDate = date.toLocaleDateString('en-US', DATE_FORMAT)
+  const visibleEvents = events.slice(0, MAX_VISIBLE_EVENTS)
+  const overflowCount = events.length - MAX_VISIBLE_EVENTS
+  const hasOverflow = overflowCount > 0
+  const hasTimedEvents = timedEvents && timedEvents.length > 0
+
+  const handleEventClick = (
+    event: YearbirdEvent,
+    e: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    if (onEventClick) {
+      onEventClick(event, { x: e.clientX, y: e.clientY })
+    }
+  }
+
+  return (
+    <Popover className="relative h-full w-full">
+      <PopoverButton as="div" className="h-full w-full cursor-pointer">
+        {children}
+      </PopoverButton>
+
+      <PopoverPanel
+        anchor={{ to: 'right start', gap: 12, padding: 16 }}
+        className="z-50 w-80 max-h-[80vh] flex flex-col rounded-lg border border-zinc-200 bg-white shadow-lg focus:outline-none"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-zinc-100 px-4 py-3">
+          <h3 className="text-sm font-semibold text-zinc-900">{formattedDate}</h3>
+          <CloseButton
+            className="rounded p-1 text-zinc-400 transition hover:bg-zinc-100 hover:text-zinc-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+            aria-label="Close popover"
+          >
+            <XIcon className="size-4" />
+          </CloseButton>
+        </div>
+
+        {/* All-day events list */}
+        <div className="shrink-0 px-2 py-2">
+          {visibleEvents.length === 0 ? (
+            <p className="px-2 py-3 text-center text-sm text-zinc-500">
+              {hasTimedEvents ? 'No all-day events' : 'No events'}
+            </p>
+          ) : (
+            <ul className="space-y-1" role="list">
+              {visibleEvents.map((event) => {
+                const category = getCategoryConfig(event.category, categories)
+                const eventColor = event.calendarColor ?? category.color
+
+                return (
+                  <li key={event.id}>
+                    <button
+                      type="button"
+                      onClick={(e) => handleEventClick(event, e)}
+                      className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left transition hover:bg-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-sky-500"
+                    >
+                      <span
+                        className="h-2.5 w-2.5 shrink-0 rounded-full"
+                        style={{ backgroundColor: eventColor }}
+                        aria-hidden="true"
+                      />
+                      <span className="truncate text-sm text-zinc-700">{event.title}</span>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+
+          {/* Overflow link */}
+          {hasOverflow ? (
+            <a
+              href={googleCalendarDayUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-2 block px-2 text-xs text-zinc-500 transition hover:text-zinc-700 hover:underline"
+            >
+              +{overflowCount} more — View all in Google
+            </a>
+          ) : null}
+        </div>
+
+        {/* Day column view for timed events */}
+        {hasTimedEvents ? (
+          <div className="min-h-0 flex-1 overflow-hidden border-t border-zinc-100">
+            <div className="px-4 py-2 text-xs font-medium text-zinc-500">Schedule</div>
+            <div className="overflow-y-auto px-2 pb-2" style={{ maxHeight: 'calc(80vh - 200px)' }}>
+              <DayColumnView
+                events={timedEvents}
+                categories={categories}
+                onEventClick={onEventClick}
+              />
+            </div>
+          </div>
+        ) : null}
+
+        {/* Footer */}
+        <div className="flex items-center gap-2 border-t border-zinc-100 px-4 py-3">
+          <a
+            href={googleCalendarDayUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-xs font-medium text-zinc-700 transition hover:bg-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+          >
+            Open Day
+            <ExternalLinkIcon className="size-3.5" />
+          </a>
+          <a
+            href={googleCalendarCreateUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-1"
+          >
+            <PlusIcon className="size-3.5" />
+            New Event
+          </a>
+        </div>
+      </PopoverPanel>
+    </Popover>
+  )
+}
+
+// Internal icon components
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M18 6L6 18" />
+      <path d="M6 6l12 12" />
+    </svg>
+  )
+}
+
+function PlusIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </svg>
+  )
+}

--- a/src/components/calendar/EventBars.test.tsx
+++ b/src/components/calendar/EventBars.test.tsx
@@ -34,7 +34,7 @@ describe('EventBars', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('adds hit slop classes for easier hover targets', () => {
+  it('adds hit slop classes for easier click targets', () => {
     const bar = buildBar()
 
     render(<EventBars bars={[bar]} />)
@@ -46,22 +46,11 @@ describe('EventBars', () => {
     )
   })
 
-  it('fires click, hover, and keyboard handlers', () => {
+  it('fires click handler with position on click, focus, and keyboard', () => {
     const onEventClick = vi.fn()
-    const onEventHover = vi.fn()
-    const onEventMove = vi.fn()
-    const onEventLeave = vi.fn()
     const bar = buildBar()
 
-    render(
-      <EventBars
-        bars={[bar]}
-        onEventClick={onEventClick}
-        onEventHover={onEventHover}
-        onEventMove={onEventMove}
-        onEventLeave={onEventLeave}
-      />
-    )
+    render(<EventBars bars={[bar]} onEventClick={onEventClick} />)
 
     const element = screen.getByRole('button', { name: 'Trip' })
     vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
@@ -75,20 +64,36 @@ describe('EventBars', () => {
       y: 100,
       toJSON: () => ({}),
     } as DOMRect)
-    fireEvent.mouseEnter(element, { clientX: 10, clientY: 20 })
-    fireEvent.mouseMove(element, { clientX: 12, clientY: 24 })
-    fireEvent.mouseLeave(element)
-    fireEvent.focus(element)
-    fireEvent.blur(element)
-    fireEvent.click(element)
-    fireEvent.keyDown(element, { key: 'Enter' })
-    fireEvent.keyDown(element, { key: ' ' })
 
-    expect(onEventHover).toHaveBeenNthCalledWith(1, bar.event, { x: 10, y: 20 }, 'pointer')
-    expect(onEventHover).toHaveBeenNthCalledWith(2, bar.event, { x: 150, y: 120 }, 'focus')
-    expect(onEventMove).toHaveBeenCalledTimes(1)
-    expect(onEventLeave).toHaveBeenNthCalledWith(1, bar.event.id)
-    expect(onEventLeave).toHaveBeenNthCalledWith(2, bar.event.id)
-    expect(onEventClick).toHaveBeenCalledTimes(3)
+    // Click fires with mouse position
+    fireEvent.click(element, { clientX: 75, clientY: 110 })
+    expect(onEventClick).toHaveBeenNthCalledWith(1, bar.event, { x: 75, y: 110 })
+
+    // Focus fires with calculated center position
+    fireEvent.focus(element)
+    expect(onEventClick).toHaveBeenNthCalledWith(2, bar.event, { x: 150, y: 120 })
+
+    // Enter key fires with calculated center position
+    fireEvent.keyDown(element, { key: 'Enter' })
+    expect(onEventClick).toHaveBeenNthCalledWith(3, bar.event, { x: 150, y: 120 })
+
+    // Space key fires with calculated center position
+    fireEvent.keyDown(element, { key: ' ' })
+    expect(onEventClick).toHaveBeenNthCalledWith(4, bar.event, { x: 150, y: 120 })
+
+    expect(onEventClick).toHaveBeenCalledTimes(4)
+  })
+
+  it('ignores non-activation keyboard events', () => {
+    const onEventClick = vi.fn()
+    const bar = buildBar()
+
+    render(<EventBars bars={[bar]} onEventClick={onEventClick} />)
+
+    const element = screen.getByRole('button', { name: 'Trip' })
+    fireEvent.keyDown(element, { key: 'Tab' })
+    fireEvent.keyDown(element, { key: 'Escape' })
+
+    expect(onEventClick).not.toHaveBeenCalled()
   })
 })

--- a/src/components/calendar/EventBars.test.tsx
+++ b/src/components/calendar/EventBars.test.tsx
@@ -46,7 +46,7 @@ describe('EventBars', () => {
     )
   })
 
-  it('fires click handler with position on click, focus, and keyboard', () => {
+  it('fires click handler with position on click and keyboard', () => {
     const onEventClick = vi.fn()
     const bar = buildBar()
 
@@ -69,19 +69,19 @@ describe('EventBars', () => {
     fireEvent.click(element, { clientX: 75, clientY: 110 })
     expect(onEventClick).toHaveBeenNthCalledWith(1, bar.event, { x: 75, y: 110 })
 
-    // Focus fires with calculated center position
+    // Focus alone does NOT fire (prevents double-trigger when clicking)
     fireEvent.focus(element)
-    expect(onEventClick).toHaveBeenNthCalledWith(2, bar.event, { x: 150, y: 120 })
+    expect(onEventClick).toHaveBeenCalledTimes(1)
 
     // Enter key fires with calculated center position
     fireEvent.keyDown(element, { key: 'Enter' })
-    expect(onEventClick).toHaveBeenNthCalledWith(3, bar.event, { x: 150, y: 120 })
+    expect(onEventClick).toHaveBeenNthCalledWith(2, bar.event, { x: 150, y: 120 })
 
     // Space key fires with calculated center position
     fireEvent.keyDown(element, { key: ' ' })
-    expect(onEventClick).toHaveBeenNthCalledWith(4, bar.event, { x: 150, y: 120 })
+    expect(onEventClick).toHaveBeenNthCalledWith(3, bar.event, { x: 150, y: 120 })
 
-    expect(onEventClick).toHaveBeenCalledTimes(4)
+    expect(onEventClick).toHaveBeenCalledTimes(3)
   })
 
   it('ignores non-activation keyboard events', () => {

--- a/src/components/calendar/EventBars.tsx
+++ b/src/components/calendar/EventBars.tsx
@@ -1,4 +1,4 @@
-import type { FocusEvent, KeyboardEvent, MouseEvent } from 'react'
+import type { KeyboardEvent, MouseEvent } from 'react'
 import clsx from 'clsx'
 import type { EventBar } from '../../utils/eventBars'
 import type { YearbirdEvent } from '../../types/calendar'
@@ -103,11 +103,6 @@ function EventBarItem({
     }
   }
 
-  const handleFocus = (event: FocusEvent<HTMLDivElement>) => {
-    const rect = event.currentTarget.getBoundingClientRect()
-    onClick({ x: rect.left + rect.width / 2, y: rect.top + rect.height })
-  }
-
   return (
     <div
       className="group pointer-events-auto absolute"
@@ -136,7 +131,6 @@ function EventBarItem({
         aria-label={bar.event.title}
         aria-describedby={describedBy}
         onClick={handleClick}
-        onFocus={handleFocus}
         onKeyDown={handleKeyDown}
       >
         <span className="truncate">{bar.event.title}</span>

--- a/src/components/calendar/EventListItem.test.tsx
+++ b/src/components/calendar/EventListItem.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import type { YearbirdEvent } from '../../types/calendar'
+import type { CategoryConfig } from '../../types/categories'
+import { EventListItem } from './EventListItem'
+
+/**
+ * Creates a mock YearbirdEvent with sensible defaults.
+ * Override any properties as needed for specific test cases.
+ */
+const createMockEvent = (overrides?: Partial<YearbirdEvent>): YearbirdEvent => ({
+  id: 'test-1',
+  title: 'Test Event',
+  startDate: '2025-01-15',
+  endDate: '2025-01-15',
+  isAllDay: true,
+  isMultiDay: false,
+  isSingleDayTimed: false,
+  durationDays: 1,
+  googleLink: 'https://calendar.google.com/calendar/event?eid=test123',
+  category: 'work',
+  color: '#8B5CF6',
+  calendarId: 'primary',
+  calendarName: 'Work Calendar',
+  calendarColor: '#38BDF8',
+  ...overrides,
+})
+
+const mockCategory: CategoryConfig = {
+  category: 'work',
+  color: '#8B5CF6',
+  label: 'Work',
+  keywords: [],
+}
+
+const defaultProps = {
+  event: createMockEvent(),
+  category: mockCategory,
+}
+
+describe('EventListItem', () => {
+  it('renders event title', () => {
+    render(<EventListItem {...defaultProps} />)
+
+    expect(screen.getByText('Test Event')).toBeInTheDocument()
+  })
+
+  it('renders calendar name when available', () => {
+    render(<EventListItem {...defaultProps} />)
+
+    expect(screen.getByText('Work Calendar')).toBeInTheDocument()
+  })
+
+  it('uses calendarId as fallback when calendarName is not available', () => {
+    const event = createMockEvent({ calendarName: undefined })
+    render(<EventListItem {...defaultProps} event={event} />)
+
+    expect(screen.getByText('primary')).toBeInTheDocument()
+  })
+
+  it('renders color dot with event color', () => {
+    const event = createMockEvent({ color: '#FF0000' })
+    render(<EventListItem {...defaultProps} event={event} />)
+
+    const colorDot = screen.getByRole('button').querySelector('span[aria-hidden="true"]')
+    expect(colorDot).toHaveStyle({ backgroundColor: '#FF0000' })
+  })
+
+  it('falls back to category color when event color is not available', () => {
+    const event = createMockEvent({ color: undefined })
+    render(<EventListItem {...defaultProps} event={event} />)
+
+    const colorDot = screen.getByRole('button').querySelector('span[aria-hidden="true"]')
+    expect(colorDot).toHaveStyle({ backgroundColor: '#8B5CF6' })
+  })
+
+  it('calls onClick when clicked', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(<EventListItem {...defaultProps} onClick={onClick} />)
+
+    await user.click(screen.getByRole('button'))
+
+    expect(onClick).toHaveBeenCalledWith(
+      defaultProps.event,
+      expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) })
+    )
+  })
+
+  it('calls onClick on Enter key', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(<EventListItem {...defaultProps} onClick={onClick} />)
+
+    const button = screen.getByRole('button')
+    button.focus()
+    await user.keyboard('{Enter}')
+
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('calls onClick on Space key', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(<EventListItem {...defaultProps} onClick={onClick} />)
+
+    const button = screen.getByRole('button')
+    button.focus()
+    await user.keyboard(' ')
+
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('renders external link when googleLink exists', () => {
+    render(<EventListItem {...defaultProps} />)
+
+    const externalLink = screen.getByRole('link', { name: /Open Test Event in Google Calendar/i })
+    expect(externalLink).toHaveAttribute('href', defaultProps.event.googleLink)
+    expect(externalLink).toHaveAttribute('target', '_blank')
+  })
+
+  it('does not render external link when googleLink is not available', () => {
+    const event = createMockEvent({ googleLink: undefined })
+    render(<EventListItem {...defaultProps} event={event} />)
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('applies highlighted styles when isHighlighted is true', () => {
+    render(<EventListItem {...defaultProps} isHighlighted />)
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveClass('bg-zinc-100')
+  })
+
+  it('applies hover styles when not highlighted', () => {
+    render(<EventListItem {...defaultProps} isHighlighted={false} />)
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveClass('hover:bg-zinc-50')
+  })
+
+  describe('Accessibility', () => {
+    it('has correct role and tabIndex', () => {
+      render(<EventListItem {...defaultProps} />)
+
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('tabIndex', '0')
+    })
+
+    it('has descriptive aria-label', () => {
+      render(<EventListItem {...defaultProps} />)
+
+      const button = screen.getByRole('button', { name: 'Test Event' })
+      expect(button).toBeInTheDocument()
+    })
+
+    it('stops propagation when external link is clicked', async () => {
+      const user = userEvent.setup()
+      const onClick = vi.fn()
+      render(<EventListItem {...defaultProps} onClick={onClick} />)
+
+      const externalLink = screen.getByRole('link')
+      await user.click(externalLink)
+
+      // onClick should NOT be called when clicking external link
+      expect(onClick).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/calendar/EventListItem.tsx
+++ b/src/components/calendar/EventListItem.tsx
@@ -1,0 +1,115 @@
+import { useCallback, type KeyboardEvent, type MouseEvent } from 'react'
+import type { YearbirdEvent } from '../../types/calendar'
+import type { CategoryConfig } from '../../types/categories'
+import { ExternalLinkIcon } from '../icons/ExternalLinkIcon'
+
+interface EventListItemProps {
+  event: YearbirdEvent
+  category: CategoryConfig
+  onClick?: (event: YearbirdEvent, position: { x: number; y: number }) => void
+  onKeyDown?: (e: KeyboardEvent) => void
+  isHighlighted?: boolean
+}
+
+/**
+ * EventListItem displays an individual event row inside the DaySummaryPopover.
+ *
+ * @example
+ * <EventListItem
+ *   event={event}
+ *   category={category}
+ *   onClick={(e, pos) => openTooltip(e, pos)}
+ *   isHighlighted={selectedIndex === index}
+ * />
+ */
+export function EventListItem({
+  event,
+  category,
+  onClick,
+  onKeyDown,
+  isHighlighted = false,
+}: EventListItemProps) {
+  const calendarLabel = event.calendarName ?? event.calendarId
+  const dotColor = event.color || category.color
+
+  const handleClick = useCallback(
+    (e: MouseEvent<HTMLDivElement>) => {
+      onClick?.(event, { x: e.clientX, y: e.clientY })
+    },
+    [event, onClick]
+  )
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      // Handle Enter/Space to trigger click
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        const rect = e.currentTarget.getBoundingClientRect()
+        onClick?.(event, { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 })
+      }
+      // Forward other key events to parent handler
+      onKeyDown?.(e)
+    },
+    [event, onClick, onKeyDown]
+  )
+
+  const handleExternalLinkClick = useCallback(
+    (e: MouseEvent<HTMLAnchorElement>) => {
+      e.stopPropagation()
+    },
+    []
+  )
+
+  const handleExternalLinkKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLAnchorElement>) => {
+      // Prevent row handler from intercepting link activation
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.stopPropagation()
+      }
+    },
+    []
+  )
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={`flex cursor-pointer items-start gap-3 rounded-md px-2 py-1.5 transition ${
+        isHighlighted ? 'bg-zinc-100' : 'hover:bg-zinc-50'
+      } focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500`}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      aria-label={event.title}
+    >
+      {/* Color dot */}
+      <span
+        className="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full border border-zinc-200"
+        style={{ backgroundColor: dotColor }}
+        aria-hidden="true"
+      />
+
+      {/* Event details */}
+      <div className="min-w-0 flex-1">
+        <p className="line-clamp-2 text-sm font-medium text-zinc-900">{event.title}</p>
+        {calendarLabel ? (
+          <p className="truncate text-xs text-zinc-500">{calendarLabel}</p>
+        ) : null}
+      </div>
+
+      {/* External link icon */}
+      {event.googleLink ? (
+        <a
+          href={event.googleLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-0.5 flex-shrink-0 rounded p-1 text-zinc-400 transition hover:bg-zinc-100 hover:text-zinc-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+          aria-label={`Open ${event.title} in Google Calendar`}
+          onClick={handleExternalLinkClick}
+          onKeyDown={handleExternalLinkKeyDown}
+        >
+          <ExternalLinkIcon className="h-4 w-4" />
+        </a>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/calendar/YearGrid.test.tsx
+++ b/src/components/calendar/YearGrid.test.tsx
@@ -304,15 +304,17 @@ describe('YearGrid', () => {
       />
     )
 
-    fireEvent.mouseEnter(screen.getByRole('button', { name: /rent payment/i }), {
+    // Click event bar to show tooltip
+    fireEvent.click(screen.getByRole('button', { name: /rent payment/i }), {
       clientX: 120,
       clientY: 80,
     })
+    // Wait for tooltip and click hide button
     fireEvent.click(await screen.findByRole('button', { name: /hide events like rent payment/i }))
     expect(onHideEvent).toHaveBeenCalledWith('Rent Payment')
   })
 
-  it('hides single-day events via tooltip action', async () => {
+  it('hides single-day events via tooltip action in scrollable mode', async () => {
     vi.stubGlobal('ResizeObserver', ResizeObserverMock)
     const onHideEvent = vi.fn()
     const events = [
@@ -325,19 +327,24 @@ describe('YearGrid', () => {
       }),
     ]
 
-    const { container } = render(
+    render(
       <YearGrid
         year={2025}
         events={events}
         today={new Date(2025, 0, 1)}
         onHideEvent={onHideEvent}
         categories={getAllCategories()}
+        isScrollable={true}
+        scrollDensity={60}
       />
     )
 
-    const dayCell = container.querySelector('[data-date="2025-02-10"]')
-    expect(dayCell).not.toBeNull()
-    fireEvent.mouseEnter(dayCell as HTMLElement, { clientX: 160, clientY: 100 })
+    // In scrollable mode, click the event item to show tooltip
+    const eventItem = screen.getByRole('button', { name: 'Doctor' })
+    expect(eventItem).not.toBeNull()
+    fireEvent.click(eventItem, { clientX: 160, clientY: 100 })
+
+    // Wait for tooltip and click hide button
     fireEvent.click(await screen.findByRole('button', { name: /hide events like doctor/i }))
     expect(onHideEvent).toHaveBeenCalledWith('Doctor')
   })

--- a/src/hooks/useTooltip.test.tsx
+++ b/src/hooks/useTooltip.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { YearbirdEvent } from '../types/calendar'
 
 const buildEvent = (overrides: Partial<YearbirdEvent> = {}): YearbirdEvent => ({
@@ -21,8 +21,7 @@ describe('useTooltip', () => {
     vi.unstubAllGlobals()
   })
 
-  it('shows and hides tooltip with delay', async () => {
-    vi.useFakeTimers()
+  it('shows tooltip when clicking an event', async () => {
     const { useTooltip } = await import('./useTooltip')
     const event = buildEvent()
 
@@ -34,279 +33,79 @@ describe('useTooltip', () => {
 
     expect(result.current.tooltip.event).toEqual(event)
     expect(result.current.tooltip.position).toEqual({ x: 10, y: 20 })
-
-    act(() => {
-      result.current.cancelHideTooltip()
-      result.current.scheduleHideTooltip()
-      vi.advanceTimersByTime(1000)
-    })
-
-    expect(result.current.tooltip.event).toBeNull()
-    vi.useRealTimers()
   })
 
-  describe('with requestAnimationFrame', () => {
-    beforeEach(() => {
-      const raf = vi.fn((callback: FrameRequestCallback) => {
-        callback(0)
-        return 1
-      })
-      vi.stubGlobal('requestAnimationFrame', raf)
-      vi.stubGlobal('cancelAnimationFrame', vi.fn())
-      vi.resetModules()
-    })
-
-    it('updates position with requestAnimationFrame', async () => {
-      const { useTooltip } = await import('./useTooltip')
-      const event = buildEvent()
-      const { result } = renderHook(() => useTooltip())
-
-      act(() => {
-        result.current.showTooltip(event, { x: 4, y: 8 }, 'focus')
-      })
-
-      act(() => {
-        result.current.updateTooltipPosition({ x: 12, y: 24 })
-      })
-
-      act(() => {
-        result.current.updateTooltipPosition({ x: 12, y: 24 })
-      })
-
-      expect(result.current.tooltip.position).toEqual({ x: 12, y: 24 })
-    })
-
-    it('ignores position updates when no event is active', async () => {
-      const { useTooltip } = await import('./useTooltip')
-      const { result } = renderHook(() => useTooltip())
-
-      act(() => {
-        result.current.updateTooltipPosition({ x: 5, y: 5 })
-      })
-
-      expect(result.current.tooltip.event).toBeNull()
-    })
-
-    it('locks pointer-driven tooltips after opening', async () => {
-      const { useTooltip } = await import('./useTooltip')
-      const event = buildEvent({ id: 'event-locked' })
-      const { result } = renderHook(() => useTooltip())
-
-      act(() => {
-        result.current.showTooltip(event, { x: 8, y: 12 }, 'pointer')
-      })
-
-      act(() => {
-        result.current.updateTooltipPosition({ x: 20, y: 30 })
-      })
-
-      expect(result.current.tooltip.position).toEqual({ x: 8, y: 12 })
-    })
-  })
-
-  it('skips scheduling when a frame is already pending', async () => {
-    const callbacks: FrameRequestCallback[] = []
-    const raf = vi.fn((callback: FrameRequestCallback) => {
-      callbacks.push(callback)
-      return callbacks.length
-    })
-    vi.stubGlobal('requestAnimationFrame', raf)
-    vi.stubGlobal('cancelAnimationFrame', vi.fn())
-    vi.resetModules()
-
+  it('toggles tooltip off when clicking the same event', async () => {
     const { useTooltip } = await import('./useTooltip')
+    const event = buildEvent()
+
     const { result } = renderHook(() => useTooltip())
 
+    // Click to show
     act(() => {
-      result.current.updateTooltipPosition({ x: 3, y: 7 })
+      result.current.showTooltip(event, { x: 10, y: 20 })
     })
+    expect(result.current.tooltip.event).toEqual(event)
 
+    // Click same event to toggle off
     act(() => {
-      result.current.updateTooltipPosition({ x: 5, y: 9 })
+      result.current.showTooltip(event, { x: 10, y: 20 })
     })
-
-    expect(raf).toHaveBeenCalledTimes(1)
-
-    act(() => {
-      callbacks[0]?.(0)
-    })
-
-  })
-
-  it('hides immediately for focus-driven tooltips', async () => {
-    const { useTooltip } = await import('./useTooltip')
-    const event = buildEvent({ id: 'focus-hide' })
-    const { result } = renderHook(() => useTooltip())
-
-    act(() => {
-      result.current.showTooltip(event, { x: 6, y: 9 }, 'focus')
-    })
-
-    act(() => {
-      result.current.scheduleHideTooltip()
-    })
-
     expect(result.current.tooltip.event).toBeNull()
   })
 
-  it('immediately switches tooltips when hovering a new event during hide delay', async () => {
-    vi.useFakeTimers()
+  it('switches tooltip when clicking a different event', async () => {
     const { useTooltip } = await import('./useTooltip')
     const eventA = buildEvent({ id: 'event-a' })
     const eventB = buildEvent({ id: 'event-b' })
+
     const { result } = renderHook(() => useTooltip())
 
     act(() => {
-      result.current.showTooltip(eventA, { x: 2, y: 4 }, 'pointer')
-    })
-
-    act(() => {
-      result.current.scheduleHideTooltip()
-    })
-
-    // New event should show immediately - no need to wait for delay
-    act(() => {
-      result.current.showTooltip(eventB, { x: 8, y: 10 }, 'pointer')
-    })
-
-    expect(result.current.tooltip.event).toEqual(eventB)
-
-    // Delay should have been cancelled, so advancing time should not hide tooltip
-    act(() => {
-      vi.advanceTimersByTime(1000)
-    })
-
-    expect(result.current.tooltip.event).toEqual(eventB)
-    vi.useRealTimers()
-  })
-
-  it('handles rapid hover across multiple events without flicker', async () => {
-    vi.useFakeTimers()
-    const { useTooltip } = await import('./useTooltip')
-    const eventA = buildEvent({ id: 'event-a' })
-    const eventB = buildEvent({ id: 'event-b' })
-    const eventC = buildEvent({ id: 'event-c' })
-    const eventD = buildEvent({ id: 'event-d' })
-    const { result } = renderHook(() => useTooltip())
-
-    // Simulate rapid mouse movement across 4 events
-    act(() => {
-      result.current.showTooltip(eventA, { x: 1, y: 1 }, 'pointer')
+      result.current.showTooltip(eventA, { x: 1, y: 1 })
     })
     expect(result.current.tooltip.event?.id).toBe('event-a')
 
     act(() => {
-      result.current.scheduleHideTooltip()
-      result.current.showTooltip(eventB, { x: 2, y: 2 }, 'pointer')
+      result.current.showTooltip(eventB, { x: 2, y: 2 })
     })
     expect(result.current.tooltip.event?.id).toBe('event-b')
-
-    act(() => {
-      result.current.scheduleHideTooltip()
-      result.current.showTooltip(eventC, { x: 3, y: 3 }, 'pointer')
-    })
-    expect(result.current.tooltip.event?.id).toBe('event-c')
-
-    act(() => {
-      result.current.scheduleHideTooltip()
-      result.current.showTooltip(eventD, { x: 4, y: 4 }, 'pointer')
-    })
-    expect(result.current.tooltip.event?.id).toBe('event-d')
-
-    // Final event should persist after delay (no hide scheduled since we're still on an event)
-    act(() => {
-      vi.advanceTimersByTime(1000)
-    })
-    expect(result.current.tooltip.event?.id).toBe('event-d')
-
-    vi.useRealTimers()
   })
 
-  it('falls back to immediate updates when raf is unavailable', async () => {
-    vi.stubGlobal('requestAnimationFrame', undefined)
-    vi.stubGlobal('cancelAnimationFrame', undefined)
-    vi.resetModules()
-
+  it('hides tooltip immediately with hideTooltip', async () => {
     const { useTooltip } = await import('./useTooltip')
-    const event = buildEvent({ id: 'event-2' })
+    const event = buildEvent()
+
     const { result } = renderHook(() => useTooltip())
 
     act(() => {
-      result.current.showTooltip(event, { x: 1, y: 1 }, 'focus')
+      result.current.showTooltip(event, { x: 10, y: 20 })
     })
+    expect(result.current.tooltip.event).not.toBeNull()
 
     act(() => {
-      result.current.updateTooltipPosition({ x: 2, y: 3 })
+      result.current.hideTooltip()
     })
-
-    act(() => {
-      result.current.updateTooltipPosition({ x: 6, y: 9 })
-    })
-
-    expect(result.current.tooltip.position).toEqual({ x: 6, y: 9 })
-  })
-
-  it('ignores updates without an active event when raf is unavailable', async () => {
-    vi.stubGlobal('requestAnimationFrame', undefined)
-    vi.stubGlobal('cancelAnimationFrame', undefined)
-    vi.resetModules()
-
-    const { useTooltip } = await import('./useTooltip')
-    const { result } = renderHook(() => useTooltip())
-
-    act(() => {
-      result.current.updateTooltipPosition({ x: 4, y: 6 })
-    })
-
     expect(result.current.tooltip.event).toBeNull()
   })
 
-  it('skips updating when position has not changed and raf is unavailable', async () => {
-    vi.stubGlobal('requestAnimationFrame', undefined)
-    vi.stubGlobal('cancelAnimationFrame', undefined)
-    vi.resetModules()
-
+  it('returns a tooltipRef for click-away detection', async () => {
     const { useTooltip } = await import('./useTooltip')
-    const event = buildEvent({ id: 'event-same-position' })
+
     const { result } = renderHook(() => useTooltip())
 
-    act(() => {
-      result.current.showTooltip(event, { x: 5, y: 7 }, 'focus')
-    })
-
-    act(() => {
-      result.current.updateTooltipPosition({ x: 5, y: 7 })
-    })
-
-    expect(result.current.tooltip.position).toEqual({ x: 5, y: 7 })
+    expect(result.current.tooltipRef).toBeDefined()
+    expect(result.current.tooltipRef.current).toBeNull()
   })
 
-  it('skips updating when position has not changed with requestAnimationFrame', async () => {
-    const callbacks: FrameRequestCallback[] = []
-    const raf = vi.fn((callback: FrameRequestCallback) => {
-      callbacks.push(callback)
-      return callbacks.length
-    })
-    vi.stubGlobal('requestAnimationFrame', raf)
-    vi.stubGlobal('cancelAnimationFrame', vi.fn())
-    vi.resetModules()
-
+  it('provides backward-compatible no-op functions', async () => {
     const { useTooltip } = await import('./useTooltip')
-    const event = buildEvent({ id: 'event-raf-same' })
+
     const { result } = renderHook(() => useTooltip())
 
-    act(() => {
-      result.current.showTooltip(event, { x: 8, y: 12 }, 'focus')
-    })
-
-    act(() => {
-      result.current.updateTooltipPosition({ x: 8, y: 12 })
-    })
-
-    act(() => {
-      callbacks[0]?.(0)
-    })
-
-    expect(result.current.tooltip.position).toEqual({ x: 8, y: 12 })
+    // These should not throw
+    expect(() => result.current.updateTooltipPosition({ x: 0, y: 0 })).not.toThrow()
+    expect(() => result.current.cancelHideTooltip()).not.toThrow()
+    expect(() => result.current.scheduleHideTooltip()).not.toThrow()
   })
 })

--- a/src/hooks/useTooltip.ts
+++ b/src/hooks/useTooltip.ts
@@ -11,9 +11,6 @@ interface TooltipState {
 
 const DEFAULT_POSITION = { x: 0, y: 0 }
 const DEFAULT_SOURCE: TooltipSource = 'pointer'
-const HIDE_DELAY_MS = 1000
-const CAN_ANIMATE = typeof requestAnimationFrame === 'function'
-const CANCEL_ANIMATION = typeof cancelAnimationFrame === 'function' ? cancelAnimationFrame : null
 
 export function useTooltip() {
   const [tooltip, setTooltip] = useState<TooltipState>({
@@ -21,119 +18,66 @@ export function useTooltip() {
     position: DEFAULT_POSITION,
     source: DEFAULT_SOURCE,
   })
-  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const positionLockedRef = useRef(false)
-  const sourceRef = useRef<TooltipSource>(DEFAULT_SOURCE)
-  const rafRef = useRef<number | null>(null)
-  const pendingPositionRef = useRef<TooltipState['position'] | null>(null)
-
-  const clearHideTimeout = useCallback(() => {
-    if (!hideTimeoutRef.current) {
-      return
-    }
-
-    clearTimeout(hideTimeoutRef.current)
-    hideTimeoutRef.current = null
-  }, [])
+  const tooltipRef = useRef<HTMLDivElement | null>(null)
 
   const showTooltip = useCallback((
     event: YearbirdEvent,
     position: TooltipState['position'],
     source: TooltipSource = DEFAULT_SOURCE
   ) => {
-    // Cancel any pending hide timer so new events show immediately without delay.
-    // The 1s delay only applies when leaving events entirely (moving to empty space).
-    clearHideTimeout()
-    positionLockedRef.current = source === 'pointer'
-    sourceRef.current = source
-    setTooltip({
-      event,
-      position,
-      source,
-    })
-  }, [clearHideTimeout])
-
-  const updateTooltipPosition = useCallback((position: TooltipState['position']) => {
-    if (positionLockedRef.current) {
-      return
-    }
-    pendingPositionRef.current = position
-    if (!CAN_ANIMATE) {
-      setTooltip((current) => {
-        if (!current.event) {
-          return current
-        }
-
-        if (current.position.x === position.x && current.position.y === position.y) {
-          return current
-        }
-
-        return { ...current, position }
-      })
-      return
-    }
-
-    if (rafRef.current !== null) {
-      return
-    }
-
-    rafRef.current = requestAnimationFrame(() => {
-      rafRef.current = null
-      const nextPosition = pendingPositionRef.current
-      if (!nextPosition) {
-        return
+    setTooltip((current) => {
+      // Toggle off if clicking the same event
+      if (current.event?.id === event.id) {
+        return { event: null, position: DEFAULT_POSITION, source: DEFAULT_SOURCE }
       }
-
-      setTooltip((current) => {
-        if (!current.event) {
-          return current
-        }
-
-        if (current.position.x === nextPosition.x && current.position.y === nextPosition.y) {
-          return current
-        }
-
-        return {
-          ...current,
-          position: nextPosition,
-        }
-      })
+      return { event, position, source }
     })
   }, [])
 
   const hideTooltip = useCallback(() => {
-    clearHideTimeout()
-    positionLockedRef.current = false
-    sourceRef.current = DEFAULT_SOURCE
     setTooltip({ event: null, position: DEFAULT_POSITION, source: DEFAULT_SOURCE })
-  }, [clearHideTimeout])
+  }, [])
 
-  const scheduleHideTooltip = useCallback(() => {
-    if (sourceRef.current !== 'pointer') {
-      hideTooltip()
-      return
-    }
-    clearHideTimeout()
-    hideTimeoutRef.current = setTimeout(() => {
-      hideTooltip()
-    }, HIDE_DELAY_MS)
-  }, [clearHideTimeout, hideTooltip])
-
+  // Click-away to close tooltip
   useEffect(() => {
-    return () => {
-      clearHideTimeout()
-      if (rafRef.current !== null && CANCEL_ANIMATION) {
-        CANCEL_ANIMATION(rafRef.current)
+    if (!tooltip.event) return
+
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as Node
+      // Don't close if clicking inside the tooltip
+      if (tooltipRef.current?.contains(target)) return
+      // Don't close if clicking on an event (it will toggle via showTooltip)
+      if ((target as Element).closest?.('[role="button"]')) return
+      hideTooltip()
+    }
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        hideTooltip()
       }
     }
-  }, [clearHideTimeout])
+
+    // Delay adding listener to avoid immediate close from the click that opened it
+    const timeoutId = setTimeout(() => {
+      document.addEventListener('click', handleClickOutside)
+      document.addEventListener('keydown', handleEscape)
+    }, 0)
+
+    return () => {
+      clearTimeout(timeoutId)
+      document.removeEventListener('click', handleClickOutside)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [tooltip.event, hideTooltip])
 
   return {
     tooltip,
+    tooltipRef,
     showTooltip,
-    updateTooltipPosition,
-    scheduleHideTooltip,
     hideTooltip,
-    cancelHideTooltip: clearHideTimeout,
+    // Keep these for backward compatibility but they're no longer used
+    updateTooltipPosition: () => {},
+    scheduleHideTooltip: hideTooltip,
+    cancelHideTooltip: () => {},
   }
 }

--- a/src/services/cache.ts
+++ b/src/services/cache.ts
@@ -10,6 +10,7 @@ import type { YearbirdEvent } from '../types/calendar'
 /**
  * Get cached events (always returns null - caching disabled).
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function getCachedEvents(_year: number, _suffix?: string): YearbirdEvent[] | null {
   return null
 }
@@ -17,6 +18,7 @@ export function getCachedEvents(_year: number, _suffix?: string): YearbirdEvent[
 /**
  * Set cached events (no-op - caching disabled).
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function setCachedEvents(_year: number, _events: YearbirdEvent[], _suffix?: string): void {
   // No-op: caching disabled
 }
@@ -24,6 +26,7 @@ export function setCachedEvents(_year: number, _events: YearbirdEvent[], _suffix
 /**
  * Clear cached events for a year (no-op - caching disabled).
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function clearCachedEvents(_year: number, _suffix?: string): void {
   // No-op: caching disabled
 }
@@ -45,6 +48,7 @@ export function clearEventCaches(): void {
 /**
  * Get cache timestamp (always returns null - caching disabled).
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function getCacheTimestamp(_year: number, _suffix?: string): Date | null {
   return null
 }

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -82,4 +82,12 @@ export interface YearbirdEvent {
   calendarName?: string
   /** Color of the calendar this event belongs to */
   calendarColor?: string
+  /** Start time in HH:MM format (24h) - only for timed events */
+  startTime?: string
+  /** End time in HH:MM format (24h) - only for timed events */
+  endTime?: string
+  /** Minutes from midnight for start time - for positioning in day column view */
+  startTimeMinutes?: number
+  /** Minutes from midnight for end time - for calculating height in day column view */
+  endTimeMinutes?: number
 }

--- a/src/utils/googleCalendar.ts
+++ b/src/utils/googleCalendar.ts
@@ -1,4 +1,5 @@
 const GOOGLE_CALENDAR_EVENT_CREATE_URL = 'https://calendar.google.com/calendar/r/eventedit'
+const GOOGLE_CALENDAR_DAY_URL = 'https://calendar.google.com/calendar/r/day'
 
 const padDatePart = (value: number) => value.toString().padStart(2, '0')
 
@@ -13,4 +14,8 @@ export const buildGoogleCalendarCreateUrl = (year: number, monthIndex: number, d
 
   const dates = `${formatDate(start)}/${formatDate(end)}`
   return `${GOOGLE_CALENDAR_EVENT_CREATE_URL}?dates=${dates}&allday=true`
+}
+
+export const buildGoogleCalendarDayUrl = (year: number, monthIndex: number, day: number) => {
+  return `${GOOGLE_CALENDAR_DAY_URL}/${year}/${monthIndex + 1}/${day}`
 }


### PR DESCRIPTION
## Summary
- 🗓️ **DaySummaryPopover**: Click any day cell to see all events in a popover with Google Calendar-style day column view for timed events
- ⏰ **DayColumnView**: Displays timed events vertically positioned by start time with smart overlapping event handling (side-by-side layout)
- 📝 **EventListItem**: Reusable event row component with calendar color dot and hover states
- 🔄 **CalendarLoadingScreen**: Polished post-login loading screen with fade-out animation that prevents FOUC

### Technical Changes
- Extended `YearbirdEvent` with time fields (`startTime`, `endTime`, `startTimeMinutes`, `endTimeMinutes`)
- Extract time data from Google Calendar `dateTime` fields in event processor
- Added `onReady` callback to `YearGrid` for detecting when all months are measured by ResizeObserver
- Fixed FOUC with 150ms debounce before starting fade (handles refetch cascade when calendar IDs change)

## Test plan
- [x] Lint passes
- [x] TypeScript passes  
- [x] All 644 unit tests pass
- [x] Production build succeeds
- [ ] Manual: Click a day with events → popover shows event list
- [ ] Manual: Timed events appear in day column view with correct vertical positioning
- [ ] Manual: Login flow shows loading screen that fades out smoothly after content loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)