### PR TITLE
fix: add yearbird.com to Worker CORS allowed origins

### DIFF
--- a/workers/oauth-exchange/wrangler.toml
+++ b/workers/oauth-exchange/wrangler.toml
@@ -4,7 +4,7 @@ compatibility_date = "2024-01-01"
 
 [vars]
 GOOGLE_CLIENT_ID = "136150782592-g30i15uq3da6e2e9ak5hmjrkpt7lndnb.apps.googleusercontent.com"
-ALLOWED_ORIGINS = "https://mjaverto.github.io,http://localhost:5173,http://localhost:4173"
+ALLOWED_ORIGINS = "https://mjaverto.github.io,https://yearbird.com,http://localhost:5173,http://localhost:4173"
 
 # Use `wrangler secret put GOOGLE_CLIENT_SECRET` for the secret
 # NEVER put the secret in this file
@@ -12,7 +12,7 @@ ALLOWED_ORIGINS = "https://mjaverto.github.io,http://localhost:5173,http://local
 # KV namespace for rate limiting
 # Create with: wrangler kv:namespace create RATE_LIMIT
 # Then update the id below with the actual namespace ID
-[[kv_namespaces]]
-binding = "RATE_LIMIT"
-id = "PLACEHOLDER_REPLACE_WITH_ACTUAL_ID"
-preview_id = "PLACEHOLDER_REPLACE_WITH_PREVIEW_ID"
+# [[kv_namespaces]]
+# binding = "RATE_LIMIT"
+# id = "PLACEHOLDER_REPLACE_WITH_ACTUAL_ID"
+# preview_id = "PLACEHOLDER_REPLACE_WITH_PREVIEW_ID"


### PR DESCRIPTION
## Summary
- Adds `https://yearbird.com` to the Worker's allowed CORS origins
- Comments out KV namespace config (placeholder IDs were blocking deployment)
- Worker falls back to in-memory rate limiting

## Root Cause
The OAuth token exchange was failing with a CORS error because `yearbird.com` wasn't in the Worker's `ALLOWED_ORIGINS` list.

## Test plan
- [x] Worker deployed successfully
- [ ] Manual UAT: Sign in from yearbird.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)