### PR TITLE
fix: make PKCE code_verifier optional for GIS popup flow

### DIFF
--- a/src/services/tokenExchange.test.ts
+++ b/src/services/tokenExchange.test.ts
@@ -168,7 +168,8 @@ describe('tokenExchange', () => {
       ).rejects.toThrow('Network error')
     })
 
-    it('sends postmessage as redirect_uri for GIS popup flow', async () => {
+    it('omits code_verifier for GIS popup flow (postmessage)', async () => {
+      // GIS popup flow doesn't support PKCE, so we omit code_verifier
       import.meta.env.VITE_OAUTH_WORKER_URL = mockWorkerUrl
 
       const mockTokenResponse = {
@@ -188,7 +189,7 @@ describe('tokenExchange', () => {
 
       await exchangeCodeForToken({
         code: 'test-auth-code',
-        codeVerifier: 'test-verifier',
+        // codeVerifier omitted - GIS popup flow
         redirectUri: 'postmessage',
       })
 
@@ -197,7 +198,7 @@ describe('tokenExchange', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           code: 'test-auth-code',
-          code_verifier: 'test-verifier',
+          // No code_verifier - GIS popup flow doesn't support PKCE
           redirect_uri: 'postmessage',
         }),
       })

--- a/workers/oauth-exchange/index.test.ts
+++ b/workers/oauth-exchange/index.test.ts
@@ -151,17 +151,27 @@ describe('OAuth Exchange Worker', () => {
       expect(body).toEqual({ error: 'missing_parameters' })
     })
 
-    it('returns 400 for missing code_verifier', async () => {
+    it('accepts request without code_verifier (GIS popup flow)', async () => {
+      // GIS popup flow doesn't support PKCE, so code_verifier is optional
+      // Mock successful Google response
+      mockGoogleFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            access_token: 'test-access-token',
+            expires_in: 3600,
+            scope: 'calendar.readonly',
+            token_type: 'Bearer',
+          }),
+      })
+
       const request = createRequest('POST', 'https://yearbird.app', {
         code: 'test-code',
-        redirect_uri: 'https://yearbird.app/callback',
+        redirect_uri: 'postmessage',
       })
 
       const response = await worker.fetch(request, mockEnv)
-      const body = await response.json()
-
-      expect(response.status).toBe(400)
-      expect(body).toEqual({ error: 'missing_parameters' })
+      expect(response.status).toBe(200)
     })
 
     it('returns 400 for missing redirect_uri', async () => {


### PR DESCRIPTION
## Summary
- GIS popup flow doesn't support PKCE (no way to pass `code_challenge`)
- When we sent `code_verifier` anyway, Google rejected with "invalid_grant"
- Now `code_verifier` is optional - only sent for redirect flow (TV mode)

## Root Cause
Google's error: `invalid_grant code_verifier or verifier is not needed`

GIS `initCodeClient` doesn't expose a way to pass `code_challenge` to the authorization endpoint, so Google has nothing to verify the `code_verifier` against.

## Changes
- `tokenExchange.ts`: Made `codeVerifier` optional in params
- `auth.ts`: Don't send `codeVerifier` for popup flow
- Worker: Accept requests without `code_verifier`
- Updated tests

## Security Note
Popup flow still has security protections:
1. Origin verification
2. Postmessage channel isolation
3. Short-lived authorization codes

## Test plan
- [x] All 766 tests pass
- [x] Lint passes
- [x] Worker deployed
- [ ] Manual UAT: Sign in with Google OAuth popup flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)